### PR TITLE
Standardise on 2-space indentation in JSON

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -1,62 +1,61 @@
 [
-
-	{
-		"directory": "country",
-		"associations": [
-			{
-				"comment": "Prime Minister of Italy",
-				"position_item_id": "Q796897"
-			},
-			{
-				"comment": "President of Italy",
-				"position_item_id": "Q332711"
-			}
-		],
-		"area_type_wikidata_item_id": "Q6256",
-		"name_columns": {
-			"lang:it_IT": "name_it",
-			"lang:en_US": "name_en"
-		}
-	},
-	{
-		"directory": "regions",
-		"associations": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		],
-		"area_type_wikidata_item_id":"Q16110",
-		"name_columns": {
-			"lang:it_IT": "REGIONE"
-                }
-        },
-        {
-		"directory": "senato-uninominal-constituencies",
-		"associations": [
-			{
-				"comment": "member of the Italian Senate",
-				"position_item_id": "Q13653224"
-			}
-		],
-		"area_type_wikidata_item_id":"Q48088606",
-		"name_columns": {
-			"lang:it_IT": "SEN17U_DEN"
-                }
-	},
-	{
-		"directory": "regional-legislature-constituencies",
-		"associations": [
-			{
-				"comment": "consigliere regionale",
-				"position_item_id": "Q24213585"
-			}
-		],
-		"area_type_wikidata_item_id": "Q15089",
-		"name_columns": {
-			"lang:it_IT": "name_it"
-		}
-	},
+  {
+    "directory": "country",
+    "associations": [
+      {
+        "comment": "Prime Minister of Italy",
+        "position_item_id": "Q796897"
+      },
+      {
+        "comment": "President of Italy",
+        "position_item_id": "Q332711"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6256",
+    "name_columns": {
+      "lang:it_IT": "name_it",
+      "lang:en_US": "name_en"
+    }
+  },
+  {
+    "directory": "regions",
+    "associations": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q16110",
+    "name_columns": {
+      "lang:it_IT": "REGIONE"
+    }
+  },
+  {
+    "directory": "senato-uninominal-constituencies",
+    "associations": [
+      {
+        "comment": "member of the Italian Senate",
+        "position_item_id": "Q13653224"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q48088606",
+    "name_columns": {
+      "lang:it_IT": "SEN17U_DEN"
+    }
+  },
+  {
+    "directory": "regional-legislature-constituencies",
+    "associations": [
+      {
+        "comment": "consigliere regionale",
+        "position_item_id": "Q24213585"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q15089",
+    "name_columns": {
+      "lang:it_IT": "name_it"
+    }
+  },
   {
     "directory": "country",
     "associations": [
@@ -87,7 +86,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:abr" }
+    "filter": {
+      "parent": "country:it/region:abr"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -100,7 +101,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:val" }
+    "filter": {
+      "parent": "country:it/region:val"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -114,7 +117,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:bas" }
+    "filter": {
+      "parent": "country:it/region:bas"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -128,7 +133,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:cal" }
+    "filter": {
+      "parent": "country:it/region:cal"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -142,7 +149,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:cam" }
+    "filter": {
+      "parent": "country:it/region:cam"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -156,7 +165,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:emi" }
+    "filter": {
+      "parent": "country:it/region:emi"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -170,7 +181,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:fri" }
+    "filter": {
+      "parent": "country:it/region:fri"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -184,7 +197,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:laz" }
+    "filter": {
+      "parent": "country:it/region:laz"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -198,7 +213,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:lig" }
+    "filter": {
+      "parent": "country:it/region:lig"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -212,7 +229,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:lom" }
+    "filter": {
+      "parent": "country:it/region:lom"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -226,7 +245,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:mar" }
+    "filter": {
+      "parent": "country:it/region:mar"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -240,7 +261,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:mol" }
+    "filter": {
+      "parent": "country:it/region:mol"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -254,7 +277,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:pie" }
+    "filter": {
+      "parent": "country:it/region:pie"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -268,7 +293,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:sar" }
+    "filter": {
+      "parent": "country:it/region:sar"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -282,7 +309,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:sic" }
+    "filter": {
+      "parent": "country:it/region:sic"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -299,7 +328,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:tre" }
+    "filter": {
+      "parent": "country:it/region:tre"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -313,7 +344,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:tos" }
+    "filter": {
+      "parent": "country:it/region:tos"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -327,7 +360,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:umb" }
+    "filter": {
+      "parent": "country:it/region:umb"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -341,7 +376,9 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:ven" }
+    "filter": {
+      "parent": "country:it/region:ven"
+    }
   },
   {
     "directory": "regional-legislature-constituencies",
@@ -355,27 +392,29 @@
     "name_columns": {
       "lang:it_IT": "name_it"
     },
-    "filter": { "parent": "country:it/region:pug" }
+    "filter": {
+      "parent": "country:it/region:pug"
+    }
   },
   {
-		"directory": "camera-uninominal-constituencies",
-		"associations": [
-			{
-				"comment": "member of the Chamber of Deputies of the Italian Republic",
-				"position_item_id": "Q18558478"
-			}
-		],
-		"area_type_wikidata_item_id":"Q48075035",
-		"name_columns": {
-			"lang:it_IT": "CAM17U_DEN"
-		}
-	},
+    "directory": "camera-uninominal-constituencies",
+    "associations": [
+      {
+        "comment": "member of the Chamber of Deputies of the Italian Republic",
+        "position_item_id": "Q18558478"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q48075035",
+    "name_columns": {
+      "lang:it_IT": "CAM17U_DEN"
+    }
+  },
   {
     "directory": "cities",
     "associations": [
       {
         "comment": "Councillor in the City of Milan",
-        "position_item_id": "Q48626476" 
+        "position_item_id": "Q48626476"
       },
       {
         "comment": "mayor of Milan",
@@ -383,11 +422,11 @@
       },
       {
         "comment": "Councillor in the City of Rome",
-        "position_item_id": "Q48623554" 
+        "position_item_id": "Q48623554"
       },
       {
         "comment": "mayor of Rome",
-        "position_item_id": "Q23936560"       
+        "position_item_id": "Q23936560"
       }
     ],
     "area_type_wikidata_item_id": "Q747074",

--- a/config.json
+++ b/config.json
@@ -1,8 +1,7 @@
 {
-    "language_map": {
-        "lang:it_IT": "it",
-		"lang:en_US": "en"
-    },
-    "country_wikidata_id": "Q38"
+  "language_map": {
+    "lang:it_IT": "it",
+    "lang:en_US": "en"
+  },
+  "country_wikidata_id": "Q38"
 }
-

--- a/executive/index.json
+++ b/executive/index.json
@@ -1,233 +1,232 @@
 [
-	{
-        "comment": "Council of Ministers",
-        "executive_item_id": "Q3687318",
-        "positions": [
-            {
-                "comment": "Prime Minister of Italy",
-                "position_item_id": "Q796897"
-            }
-		]		
-	},
-	{
-		"comment":"Giunta Regionale del Veneto",
-		"executive_item_id":"Q3769850",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Calabria",
-		"executive_item_id":"Q3769852",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Sardegna",
-		"executive_item_id":"Q3769853",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale delle Marche",
-		"executive_item_id":"Q16560579",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Lombardia",
-		"executive_item_id":"Q17631824",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Sicilia",
-		"executive_item_id":"Q28670947",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale del Trentino-Alto Adige",
-		"executive_item_id":"Q28670983",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Valle d'Aosta",
-		"executive_item_id":"Q28671036",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale del Friuli-Venezia Giulia",
-		"executive_item_id":"Q30888246",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale dell'Emilia-Romagna",
-		"executive_item_id":"Q30888285",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Liguria",
-		"executive_item_id":"Q30888334",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Puglia",
-		"executive_item_id":"Q30888335",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale del Piemonte",
-		"executive_item_id":"Q30888345",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale dell'Abruzzo",
-		"executive_item_id":"Q30888353",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale dell'Umbria",
-		"executive_item_id":"Q30888354",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Basilicata",
-		"executive_item_id":"Q30888374",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale del Molise",
-		"executive_item_id":"Q30888413",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Campania",
-		"executive_item_id":"Q30888428",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale del Lazio",
-		"executive_item_id":"Q30888445",
-		"positions": [
-			{
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment":"Giunta regionale della Toscana",
-		"executive_item_id":"Q30888448",
-		"positions": [
-			{	
-				"comment": "president of Italian region",
-				"position_item_id": "Q3911030"
-			}
-		]
-	},
-	{
-		"comment": "giunta comunale di Milano",
-		"executive_item_id": "Q48783551",
-		"positions": [
-			{
-				"comment": "mayor of Milan",
-				"position_item_id": "Q3961545"
-			}
-		]
-	},
-	{
-		"comment": "Giunta Capitolina",
-		"executive_item_id": "Q48782474",
-		"positions": [
-			{
-				"comment": "mayor of Rome",
-				"position_item_id": "Q23936560"
-			}
-		]
-	}
-
+  {
+    "comment": "Council of Ministers",
+    "executive_item_id": "Q3687318",
+    "positions": [
+      {
+        "comment": "Prime Minister of Italy",
+        "position_item_id": "Q796897"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta Regionale del Veneto",
+    "executive_item_id": "Q3769850",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Calabria",
+    "executive_item_id": "Q3769852",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Sardegna",
+    "executive_item_id": "Q3769853",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale delle Marche",
+    "executive_item_id": "Q16560579",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Lombardia",
+    "executive_item_id": "Q17631824",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Sicilia",
+    "executive_item_id": "Q28670947",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale del Trentino-Alto Adige",
+    "executive_item_id": "Q28670983",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Valle d'Aosta",
+    "executive_item_id": "Q28671036",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale del Friuli-Venezia Giulia",
+    "executive_item_id": "Q30888246",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale dell'Emilia-Romagna",
+    "executive_item_id": "Q30888285",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Liguria",
+    "executive_item_id": "Q30888334",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Puglia",
+    "executive_item_id": "Q30888335",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale del Piemonte",
+    "executive_item_id": "Q30888345",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale dell'Abruzzo",
+    "executive_item_id": "Q30888353",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale dell'Umbria",
+    "executive_item_id": "Q30888354",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Basilicata",
+    "executive_item_id": "Q30888374",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale del Molise",
+    "executive_item_id": "Q30888413",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Campania",
+    "executive_item_id": "Q30888428",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale del Lazio",
+    "executive_item_id": "Q30888445",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta regionale della Toscana",
+    "executive_item_id": "Q30888448",
+    "positions": [
+      {
+        "comment": "president of Italian region",
+        "position_item_id": "Q3911030"
+      }
+    ]
+  },
+  {
+    "comment": "giunta comunale di Milano",
+    "executive_item_id": "Q48783551",
+    "positions": [
+      {
+        "comment": "mayor of Milan",
+        "position_item_id": "Q3961545"
+      }
+    ]
+  },
+  {
+    "comment": "Giunta Capitolina",
+    "executive_item_id": "Q48782474",
+    "positions": [
+      {
+        "comment": "mayor of Rome",
+        "position_item_id": "Q23936560"
+      }
+    ]
+  }
 ]

--- a/legislative/index.json
+++ b/legislative/index.json
@@ -1,256 +1,255 @@
 [
-    {
-        "comment": "Senate of the Republic of Italy",
-        "house_item_id": "Q633872",
-        "position_item_id": "Q13653224",
-            "terms": [
-                {
-                    "start_date": "2018-01-01",
-                        "end_date": "2018-12-31"
-                }
-            ]
-    },
-    {
-        "comment": "Regional Council of Abruzzo",
-        "house_item_id": "Q3687391",
-        "position_item_id": "Q47528624",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of the Aosta Valley",
-        "house_item_id": "Q2993782",
-        "position_item_id": "Q47529152",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Apulia",
-        "house_item_id": "Q14562680",
-        "position_item_id": "Q47529175",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Basilicata",
-        "house_item_id": "Q28670292",
-        "position_item_id": "Q47531966",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Calabria",
-        "house_item_id": "Q3687394",
-        "position_item_id": "Q47529342",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Campania",
-        "house_item_id": "Q21190093",
-        "position_item_id": "Q47536165",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Emilia-Romagna",
-        "house_item_id": "Q7309036",
-        "position_item_id": "Q47536174",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Friuli-Venezia Giulia",
-        "house_item_id": "Q3687386",
-        "position_item_id": "Q47530036",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Lazio",
-        "house_item_id": "Q3687387",
-        "position_item_id": "Q47530138",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Liguria",
-        "house_item_id": "Q21190095",
-        "position_item_id": "Q47537466",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Lombardy",
-        "house_item_id": "Q3687395",
-        "position_item_id": "Q47530307",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Marche",
-        "house_item_id": "Q14562584",
-        "position_item_id": "Q47530369",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-
-    {
-        "comment": "Regional Council of Molise",
-        "house_item_id": "Q28670291",
-        "position_item_id": "Q47536217",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Piedmont",
-        "house_item_id": "Q17154492",
-        "position_item_id": "Q47536283",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Sardinia",
-        "house_item_id": "Q3687397",
-        "position_item_id": "Q47530393",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Sicilian Regional Assembly",
-        "house_item_id": "Q2707406",
-        "position_item_id": "Q47531020",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Tuscany",
-        "house_item_id": "Q3687399",
-        "position_item_id": "Q47532269",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Umbria",
-        "house_item_id": "Q21190091",
-        "position_item_id": "Q47536348",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Regional Council of Veneto",
-        "house_item_id": "Q3687390",
-        "position_item_id": "Q47536156",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "lower house of the Parliament of Italy",
-        "house_item_id": "Q841424",
-        "position_item_id": "Q18558478",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "City Council of Milan",
-        "house_item_id": "Q28228849",
-        "position_item_id": "Q48626476",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Rome City Council",
-        "house_item_id": "Q48617968",
-        "position_item_id": "Q48623554",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    } 
+  {
+    "comment": "Senate of the Republic of Italy",
+    "house_item_id": "Q633872",
+    "position_item_id": "Q13653224",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Abruzzo",
+    "house_item_id": "Q3687391",
+    "position_item_id": "Q47528624",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of the Aosta Valley",
+    "house_item_id": "Q2993782",
+    "position_item_id": "Q47529152",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Apulia",
+    "house_item_id": "Q14562680",
+    "position_item_id": "Q47529175",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Basilicata",
+    "house_item_id": "Q28670292",
+    "position_item_id": "Q47531966",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Calabria",
+    "house_item_id": "Q3687394",
+    "position_item_id": "Q47529342",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Campania",
+    "house_item_id": "Q21190093",
+    "position_item_id": "Q47536165",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Emilia-Romagna",
+    "house_item_id": "Q7309036",
+    "position_item_id": "Q47536174",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Friuli-Venezia Giulia",
+    "house_item_id": "Q3687386",
+    "position_item_id": "Q47530036",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Lazio",
+    "house_item_id": "Q3687387",
+    "position_item_id": "Q47530138",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Liguria",
+    "house_item_id": "Q21190095",
+    "position_item_id": "Q47537466",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Lombardy",
+    "house_item_id": "Q3687395",
+    "position_item_id": "Q47530307",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Marche",
+    "house_item_id": "Q14562584",
+    "position_item_id": "Q47530369",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Molise",
+    "house_item_id": "Q28670291",
+    "position_item_id": "Q47536217",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Piedmont",
+    "house_item_id": "Q17154492",
+    "position_item_id": "Q47536283",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Sardinia",
+    "house_item_id": "Q3687397",
+    "position_item_id": "Q47530393",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Sicilian Regional Assembly",
+    "house_item_id": "Q2707406",
+    "position_item_id": "Q47531020",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Tuscany",
+    "house_item_id": "Q3687399",
+    "position_item_id": "Q47532269",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Umbria",
+    "house_item_id": "Q21190091",
+    "position_item_id": "Q47536348",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Regional Council of Veneto",
+    "house_item_id": "Q3687390",
+    "position_item_id": "Q47536156",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "lower house of the Parliament of Italy",
+    "house_item_id": "Q841424",
+    "position_item_id": "Q18558478",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "City Council of Milan",
+    "house_item_id": "Q28228849",
+    "position_item_id": "Q48626476",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Rome City Council",
+    "house_item_id": "Q48617968",
+    "position_item_id": "Q48623554",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
There doesn't seem to be a global indentation
standard for JSON (see, for example
https://stackoverflow.com/questions/18698738/what-is-the-json-indentation-level-convention).
However, @chrismytton notes that ruby's JSON.pretty_generate
produces 2-space indentation, as does the Google JSON style
guide (https://google.github.io/styleguide/jsoncstyleguide.xml)
and most of Facebook's Graph API JSON example
(https://developers.facebook.com/docs/graph-api/using-graph-api/).