### PR TITLE
Add index entries for plurinominal constituency boundaries

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -371,6 +371,18 @@
 		}
 	},
   {
+    "directory": "camera-plurinominal-constituencies",
+    "name_columns": {
+      "lang:it_IT": "CAM17P_DEN"
+    }
+  },
+  {
+    "directory": "senato-plurinominal-constituencies",
+    "name_columns": {
+      "lang:it_IT": "SEN17P_DEN"
+    }
+  },
+  {
     "directory": "cities",
     "associations": [
       {


### PR DESCRIPTION
These entries currently only contain the directory and the
name column metadata as we haven't yet decided the Wikidata
item to match the electoral districts to.

This PR relies on https://github.com/everypolitician/commons-builder/pull/4