### PR TITLE
Fix boundary lang columns

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -13,8 +13,8 @@
     ],
     "area_type_wikidata_item_id": "Q6256",
     "name_columns": {
-      "lang:it_IT": "name_it",
-      "lang:en_US": "name_en"
+      "lang:it": "name_it",
+      "lang:en": "name_en"
     }
   },
   {
@@ -27,7 +27,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:pie",
@@ -44,7 +44,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:val",
@@ -61,7 +61,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:lom",
@@ -78,7 +78,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:tre",
@@ -95,7 +95,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:ven",
@@ -112,7 +112,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:fri",
@@ -129,7 +129,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:lig",
@@ -146,7 +146,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:emi",
@@ -163,7 +163,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:tos",
@@ -180,7 +180,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:umb",
@@ -197,7 +197,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:mar",
@@ -214,7 +214,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:laz",
@@ -231,7 +231,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:abr",
@@ -248,7 +248,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:mol",
@@ -265,7 +265,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:cam",
@@ -282,7 +282,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:pug",
@@ -299,7 +299,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:bas",
@@ -316,7 +316,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:cal",
@@ -333,7 +333,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:sic",
@@ -350,7 +350,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "REGIONE"
+      "lang:it": "REGIONE"
     },
     "filter": {
       "match": "country:it/region:sar",
@@ -367,7 +367,7 @@
     ],
     "area_type_wikidata_item_id": "Q48088606",
     "name_columns": {
-      "lang:it_IT": "SEN17U_DEN"
+      "lang:it": "SEN17U_DEN"
     }
   },
   {
@@ -380,7 +380,7 @@
     ],
     "area_type_wikidata_item_id": "Q15089",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     }
   },
   {
@@ -393,7 +393,7 @@
     ],
     "area_type_wikidata_item_id": "Q47773783",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:abr"
@@ -408,7 +408,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:val"
@@ -424,7 +424,7 @@
     ],
     "area_type_wikidata_item_id": "Q47906224",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:bas"
@@ -440,7 +440,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907563",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:cal"
@@ -456,7 +456,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907618",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:cam"
@@ -472,7 +472,7 @@
     ],
     "area_type_wikidata_item_id": "Q47999722",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:emi"
@@ -488,7 +488,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907543",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:fri"
@@ -504,7 +504,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907549",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:laz"
@@ -520,7 +520,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907612",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:lig"
@@ -536,7 +536,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907571",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:lom"
@@ -552,7 +552,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907593",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:mar"
@@ -568,7 +568,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907624",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:mol"
@@ -584,7 +584,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907597",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:pie"
@@ -600,7 +600,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907586",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:sar"
@@ -616,7 +616,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907537",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:sic"
@@ -635,7 +635,7 @@
       }
     ],
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:tre"
@@ -651,7 +651,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907578",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:tos"
@@ -667,7 +667,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907606",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:umb"
@@ -683,7 +683,7 @@
     ],
     "area_type_wikidata_item_id": "Q47907555",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:ven"
@@ -699,7 +699,7 @@
     ],
     "area_type_wikidata_item_id": "Q47893691",
     "name_columns": {
-      "lang:it_IT": "name_it"
+      "lang:it": "name_it"
     },
     "filter": {
       "parent": "country:it/region:pug"
@@ -715,19 +715,19 @@
     ],
     "area_type_wikidata_item_id": "Q48075035",
     "name_columns": {
-      "lang:it_IT": "CAM17U_DEN"
+      "lang:it": "CAM17U_DEN"
     }
   },
   {
     "directory": "camera-plurinominal-constituencies",
     "name_columns": {
-      "lang:it_IT": "CAM17P_DEN"
+      "lang:it": "CAM17P_DEN"
     }
   },
   {
     "directory": "senato-plurinominal-constituencies",
     "name_columns": {
-      "lang:it_IT": "SEN17P_DEN"
+      "lang:it": "SEN17P_DEN"
     }
   },
   {
@@ -744,7 +744,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:lom/metro:mi"
@@ -764,7 +764,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:laz/metro:rm"
@@ -784,7 +784,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:cam/metro:na"
@@ -804,7 +804,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:pie/metro:to"
@@ -824,7 +824,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:sic/metro:pa"
@@ -844,7 +844,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:lig/metro:ge"
@@ -864,7 +864,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:emi/metro:bo"
@@ -884,7 +884,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:tos/metro:fi"
@@ -904,7 +904,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:pug/metro:ba"
@@ -924,7 +924,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:sic/metro:ct"
@@ -944,7 +944,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:ven/metro:ve"
@@ -964,7 +964,7 @@
     ],
     "area_type_wikidata_item_id": "Q747074",
     "name_columns": {
-      "lang:it_IT": "COMUNE17"
+      "lang:it": "COMUNE17"
     },
     "filter": {
       "parent": "country:it/region:ven/province:vr"

--- a/executive/Q16560579/current/popolo-m17n.json
+++ b/executive/Q16560579/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche"
+        "lang:it": "Marche"
       },
       "parent_id": "Q38"
     },
@@ -93,8 +93,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q17631824/current/popolo-m17n.json
+++ b/executive/Q17631824/current/popolo-m17n.json
@@ -87,7 +87,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia"
+        "lang:it": "Lombardia"
       },
       "parent_id": "Q38"
     },
@@ -112,8 +112,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q28670947/current/popolo-m17n.json
+++ b/executive/Q28670947/current/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q28670983/current/popolo-m17n.json
+++ b/executive/Q28670983/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige"
+        "lang:it": "Trentino-Alto Adige"
       },
       "parent_id": "Q38"
     },
@@ -93,8 +93,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q28671036/current/popolo-m17n.json
+++ b/executive/Q28671036/current/popolo-m17n.json
@@ -57,7 +57,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Valle d'Aosta"
+        "lang:it": "Valle d'Aosta"
       },
       "parent_id": "Q38"
     },
@@ -82,8 +82,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888246/current/popolo-m17n.json
+++ b/executive/Q30888246/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia"
+        "lang:it": "Friuli-Venezia Giulia"
       },
       "parent_id": "Q38"
     },
@@ -93,8 +93,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888285/current/popolo-m17n.json
+++ b/executive/Q30888285/current/popolo-m17n.json
@@ -87,7 +87,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna"
+        "lang:it": "Emilia-Romagna"
       },
       "parent_id": "Q38"
     },
@@ -112,8 +112,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888334/current/popolo-m17n.json
+++ b/executive/Q30888334/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria"
+        "lang:it": "Liguria"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888335/current/popolo-m17n.json
+++ b/executive/Q30888335/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia"
+        "lang:it": "Puglia"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888345/current/popolo-m17n.json
+++ b/executive/Q30888345/current/popolo-m17n.json
@@ -84,7 +84,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte"
+        "lang:it": "Piemonte"
       },
       "parent_id": "Q38"
     },
@@ -109,8 +109,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888353/current/popolo-m17n.json
+++ b/executive/Q30888353/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Abruzzo"
+        "lang:it": "Abruzzo"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888354/current/popolo-m17n.json
+++ b/executive/Q30888354/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Umbria"
+        "lang:it": "Umbria"
       },
       "parent_id": "Q38"
     },
@@ -93,8 +93,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888374/current/popolo-m17n.json
+++ b/executive/Q30888374/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Basilicata"
+        "lang:it": "Basilicata"
       },
       "parent_id": "Q38"
     },
@@ -93,8 +93,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888413/current/popolo-m17n.json
+++ b/executive/Q30888413/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Molise"
+        "lang:it": "Molise"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888428/current/popolo-m17n.json
+++ b/executive/Q30888428/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania"
+        "lang:it": "Campania"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888445/current/popolo-m17n.json
+++ b/executive/Q30888445/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio"
+        "lang:it": "Lazio"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q30888448/current/popolo-m17n.json
+++ b/executive/Q30888448/current/popolo-m17n.json
@@ -82,7 +82,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana"
+        "lang:it": "Toscana"
       },
       "parent_id": "Q38"
     },
@@ -107,8 +107,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q3687318/current/popolo-m17n.json
+++ b/executive/Q3687318/current/popolo-m17n.json
@@ -107,8 +107,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q3769850/current/popolo-m17n.json
+++ b/executive/Q3769850/current/popolo-m17n.json
@@ -83,7 +83,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -108,8 +108,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q3769852/current/popolo-m17n.json
+++ b/executive/Q3769852/current/popolo-m17n.json
@@ -82,7 +82,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria"
+        "lang:it": "Calabria"
       },
       "parent_id": "Q38"
     },
@@ -107,8 +107,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q3769853/current/popolo-m17n.json
+++ b/executive/Q3769853/current/popolo-m17n.json
@@ -492,7 +492,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna"
+        "lang:it": "Sardegna"
       },
       "parent_id": "Q38"
     },
@@ -517,8 +517,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     }

--- a/executive/Q48782474/current/popolo-m17n.json
+++ b/executive/Q48782474/current/popolo-m17n.json
@@ -243,7 +243,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio"
+        "lang:it": "Lazio"
       },
       "parent_id": "Q38"
     },
@@ -268,7 +268,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Roma"
+        "lang:it": "Roma"
       },
       "parent_id": "Q47909105"
     },
@@ -293,8 +293,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -317,7 +317,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Roma"
+        "lang:it": "Roma"
       },
       "parent_id": "Q1282"
     }

--- a/executive/Q48783551/current/popolo-m17n.json
+++ b/executive/Q48783551/current/popolo-m17n.json
@@ -71,7 +71,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia"
+        "lang:it": "Lombardia"
       },
       "parent_id": "Q38"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -120,7 +120,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Milano"
+        "lang:it": "Milano"
       },
       "parent_id": "Q1210"
     },
@@ -145,7 +145,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Milano"
+        "lang:it": "Milano"
       },
       "parent_id": "Q47997796"
     }

--- a/executive/Q50182275/current/popolo-m17n.json
+++ b/executive/Q50182275/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia"
+        "lang:it": "Puglia"
       },
       "parent_id": "Q38"
     },
@@ -93,7 +93,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Bari"
+        "lang:it": "Bari"
       },
       "parent_id": "Q47904406"
     },
@@ -118,8 +118,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -142,7 +142,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Bari"
+        "lang:it": "Bari"
       },
       "parent_id": "Q1447"
     }

--- a/executive/Q50184048/current/popolo-m17n.json
+++ b/executive/Q50184048/current/popolo-m17n.json
@@ -110,7 +110,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna"
+        "lang:it": "Emilia-Romagna"
       },
       "parent_id": "Q38"
     },
@@ -135,7 +135,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Bologna"
+        "lang:it": "Bologna"
       },
       "parent_id": "Q47998557"
     },
@@ -160,8 +160,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -184,7 +184,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Bologna"
+        "lang:it": "Bologna"
       },
       "parent_id": "Q1263"
     }

--- a/executive/Q50187115/current/popolo-m17n.json
+++ b/executive/Q50187115/current/popolo-m17n.json
@@ -98,7 +98,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -123,7 +123,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Catania"
+        "lang:it": "Catania"
       },
       "parent_id": "Q48006727"
     },
@@ -148,8 +148,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -172,7 +172,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Catania"
+        "lang:it": "Catania"
       },
       "parent_id": "Q1460"
     }

--- a/executive/Q50188306/current/popolo-m17n.json
+++ b/executive/Q50188306/current/popolo-m17n.json
@@ -84,7 +84,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana"
+        "lang:it": "Toscana"
       },
       "parent_id": "Q38"
     },
@@ -109,7 +109,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Firenze"
+        "lang:it": "Firenze"
       },
       "parent_id": "Q47998855"
     },
@@ -134,8 +134,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -158,7 +158,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Firenze"
+        "lang:it": "Firenze"
       },
       "parent_id": "Q1273"
     }

--- a/executive/Q50188992/current/popolo-m17n.json
+++ b/executive/Q50188992/current/popolo-m17n.json
@@ -61,7 +61,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria"
+        "lang:it": "Liguria"
       },
       "parent_id": "Q38"
     },
@@ -86,7 +86,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Genova"
+        "lang:it": "Genova"
       },
       "parent_id": "Q47998323"
     },
@@ -111,8 +111,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -135,7 +135,7 @@
         "lang:en": "Constituency of the Regional Council of Liguria"
       },
       "name": {
-        "lang:it_IT": "Genova"
+        "lang:it": "Genova"
       },
       "parent_id": "Q1256"
     }

--- a/executive/Q50189943/current/popolo-m17n.json
+++ b/executive/Q50189943/current/popolo-m17n.json
@@ -95,7 +95,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania"
+        "lang:it": "Campania"
       },
       "parent_id": "Q38"
     },
@@ -120,7 +120,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Napoli"
+        "lang:it": "Napoli"
       },
       "parent_id": "Q47998998"
     },
@@ -145,8 +145,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -169,7 +169,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Napoli"
+        "lang:it": "Napoli"
       },
       "parent_id": "Q1438"
     }

--- a/executive/Q50190167/current/popolo-m17n.json
+++ b/executive/Q50190167/current/popolo-m17n.json
@@ -110,7 +110,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -135,7 +135,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Palermo"
+        "lang:it": "Palermo"
       },
       "parent_id": "Q48006247"
     },
@@ -160,8 +160,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -184,7 +184,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Palermo"
+        "lang:it": "Palermo"
       },
       "parent_id": "Q1460"
     }

--- a/executive/Q50247306/current/popolo-m17n.json
+++ b/executive/Q50247306/current/popolo-m17n.json
@@ -68,7 +68,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte"
+        "lang:it": "Piemonte"
       },
       "parent_id": "Q38"
     },
@@ -93,8 +93,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -117,7 +117,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Torino"
+        "lang:it": "Torino"
       },
       "parent_id": "Q1216"
     },
@@ -142,7 +142,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Torino"
+        "lang:it": "Torino"
       },
       "parent_id": "Q47997465"
     }

--- a/executive/Q50248025/current/popolo-m17n.json
+++ b/executive/Q50248025/current/popolo-m17n.json
@@ -54,7 +54,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -79,8 +79,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -103,7 +103,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Venezia"
+        "lang:it": "Venezia"
       },
       "parent_id": "Q1243"
     },
@@ -128,7 +128,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Venezia"
+        "lang:it": "Venezia"
       },
       "parent_id": "Q47998078"
     }

--- a/executive/Q50250772/current/popolo-m17n.json
+++ b/executive/Q50250772/current/popolo-m17n.json
@@ -84,7 +84,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -109,7 +109,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Verona"
+        "lang:it": "Verona"
       },
       "parent_id": "Q47928281"
     },
@@ -134,8 +134,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -158,7 +158,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Verona"
+        "lang:it": "Verona"
       },
       "parent_id": "Q1243"
     }

--- a/legislative/Q14562584/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q14562584/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche"
+        "lang:it": "Marche"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Marche"
       },
       "name": {
-        "lang:it_IT": "Pesaro e Urbino"
+        "lang:it": "Pesaro e Urbino"
       },
       "parent_id": "Q1279"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Marche"
       },
       "name": {
-        "lang:it_IT": "Ancona"
+        "lang:it": "Ancona"
       },
       "parent_id": "Q1279"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Marche"
       },
       "name": {
-        "lang:it_IT": "Macerata"
+        "lang:it": "Macerata"
       },
       "parent_id": "Q1279"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Marche"
       },
       "name": {
-        "lang:it_IT": "Ascoli Piceno"
+        "lang:it": "Ascoli Piceno"
       },
       "parent_id": "Q1279"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Regional Council of Marche"
       },
       "name": {
-        "lang:it_IT": "Fermo"
+        "lang:it": "Fermo"
       },
       "parent_id": "Q1279"
     }

--- a/legislative/Q14562680/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q14562680/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -75,7 +75,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia"
+        "lang:it": "Puglia"
       },
       "parent_id": "Q38"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -124,7 +124,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Lecce"
+        "lang:it": "Lecce"
       },
       "parent_id": "Q1447"
     },
@@ -147,7 +147,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Barletta-Andria-Trani"
+        "lang:it": "Barletta-Andria-Trani"
       },
       "parent_id": "Q1447"
     },
@@ -170,7 +170,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Brindisi"
+        "lang:it": "Brindisi"
       },
       "parent_id": "Q1447"
     },
@@ -193,7 +193,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Taranto"
+        "lang:it": "Taranto"
       },
       "parent_id": "Q1447"
     },
@@ -216,7 +216,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Foggia"
+        "lang:it": "Foggia"
       },
       "parent_id": "Q1447"
     },
@@ -239,7 +239,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Bari"
+        "lang:it": "Bari"
       },
       "parent_id": "Q1447"
     }

--- a/legislative/Q17154492/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q17154492/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte"
+        "lang:it": "Piemonte"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Vercelli"
+        "lang:it": "Vercelli"
       },
       "parent_id": "Q1216"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Novara"
+        "lang:it": "Novara"
       },
       "parent_id": "Q1216"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Cuneo"
+        "lang:it": "Cuneo"
       },
       "parent_id": "Q1216"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Asti"
+        "lang:it": "Asti"
       },
       "parent_id": "Q1216"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Alessandria"
+        "lang:it": "Alessandria"
       },
       "parent_id": "Q1216"
     },
@@ -190,7 +190,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Biella"
+        "lang:it": "Biella"
       },
       "parent_id": "Q1216"
     },
@@ -213,7 +213,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Verbano-Cusio-Ossola"
+        "lang:it": "Verbano-Cusio-Ossola"
       },
       "parent_id": "Q1216"
     },
@@ -236,7 +236,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Torino"
+        "lang:it": "Torino"
       },
       "parent_id": "Q1216"
     }

--- a/legislative/Q21190091/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q21190091/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -75,7 +75,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Umbria"
+        "lang:it": "Umbria"
       },
       "parent_id": "Q38"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -124,7 +124,7 @@
         "lang:en": "Constituency of the Regional Council of Umbria"
       },
       "name": {
-        "lang:it_IT": "Perugia"
+        "lang:it": "Perugia"
       },
       "parent_id": "Q1280"
     },
@@ -147,7 +147,7 @@
         "lang:en": "Constituency of the Regional Council of Umbria"
       },
       "name": {
-        "lang:it_IT": "Terni"
+        "lang:it": "Terni"
       },
       "parent_id": "Q1280"
     }

--- a/legislative/Q21190093/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q21190093/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania"
+        "lang:it": "Campania"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Caserta"
+        "lang:it": "Caserta"
       },
       "parent_id": "Q1438"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Benevento"
+        "lang:it": "Benevento"
       },
       "parent_id": "Q1438"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Avellino"
+        "lang:it": "Avellino"
       },
       "parent_id": "Q1438"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Salerno"
+        "lang:it": "Salerno"
       },
       "parent_id": "Q1438"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Napoli"
+        "lang:it": "Napoli"
       },
       "parent_id": "Q1438"
     }

--- a/legislative/Q21190095/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q21190095/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria"
+        "lang:it": "Liguria"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Liguria"
       },
       "name": {
-        "lang:it_IT": "Imperia"
+        "lang:it": "Imperia"
       },
       "parent_id": "Q1256"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Liguria"
       },
       "name": {
-        "lang:it_IT": "Savona"
+        "lang:it": "Savona"
       },
       "parent_id": "Q1256"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Liguria"
       },
       "name": {
-        "lang:it_IT": "La Spezia"
+        "lang:it": "La Spezia"
       },
       "parent_id": "Q1256"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Liguria"
       },
       "name": {
-        "lang:it_IT": "Genova"
+        "lang:it": "Genova"
       },
       "parent_id": "Q1256"
     }

--- a/legislative/Q2707406/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2707406/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Trapani"
+        "lang:it": "Trapani"
       },
       "parent_id": "Q1460"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Agrigento"
+        "lang:it": "Agrigento"
       },
       "parent_id": "Q1460"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Caltanissetta"
+        "lang:it": "Caltanissetta"
       },
       "parent_id": "Q1460"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Enna"
+        "lang:it": "Enna"
       },
       "parent_id": "Q1460"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Ragusa"
+        "lang:it": "Ragusa"
       },
       "parent_id": "Q1460"
     },
@@ -190,7 +190,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Siracusa"
+        "lang:it": "Siracusa"
       },
       "parent_id": "Q1460"
     },
@@ -213,7 +213,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Palermo"
+        "lang:it": "Palermo"
       },
       "parent_id": "Q1460"
     },
@@ -236,7 +236,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Messina"
+        "lang:it": "Messina"
       },
       "parent_id": "Q1460"
     },
@@ -259,7 +259,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Catania"
+        "lang:it": "Catania"
       },
       "parent_id": "Q1460"
     }

--- a/legislative/Q28228849/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q28228849/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -176,7 +176,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia"
+        "lang:it": "Lombardia"
       },
       "parent_id": "Q38"
     },
@@ -201,8 +201,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -225,7 +225,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Milano"
+        "lang:it": "Milano"
       },
       "parent_id": "Q1210"
     },
@@ -250,7 +250,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Milano"
+        "lang:it": "Milano"
       },
       "parent_id": "Q47997796"
     }

--- a/legislative/Q28670291/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q28670291/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -75,7 +75,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Molise"
+        "lang:it": "Molise"
       },
       "parent_id": "Q38"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -124,7 +124,7 @@
         "lang:en": "Constituency of the Regional Council of Molise"
       },
       "name": {
-        "lang:it_IT": "Campobasso"
+        "lang:it": "Campobasso"
       },
       "parent_id": "Q1443"
     },
@@ -147,7 +147,7 @@
         "lang:en": "Constituency of the Regional Council of Molise"
       },
       "name": {
-        "lang:it_IT": "Isernia"
+        "lang:it": "Isernia"
       },
       "parent_id": "Q1443"
     }

--- a/legislative/Q28670292/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q28670292/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Basilicata"
+        "lang:it": "Basilicata"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Basilicata"
       },
       "name": {
-        "lang:it_IT": "Matera"
+        "lang:it": "Matera"
       },
       "parent_id": "Q1452"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Basilicata"
       },
       "name": {
-        "lang:it_IT": "Potenza"
+        "lang:it": "Potenza"
       },
       "parent_id": "Q1452"
     }

--- a/legislative/Q3687386/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687386/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia"
+        "lang:it": "Friuli-Venezia Giulia"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Friuli-Venezia Giulia"
       },
       "name": {
-        "lang:it_IT": "Udine"
+        "lang:it": "Udine"
       },
       "parent_id": "Q1250"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Friuli-Venezia Giulia"
       },
       "name": {
-        "lang:it_IT": "Gorizia"
+        "lang:it": "Gorizia"
       },
       "parent_id": "Q1250"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Friuli-Venezia Giulia"
       },
       "name": {
-        "lang:it_IT": "Trieste"
+        "lang:it": "Trieste"
       },
       "parent_id": "Q1250"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Friuli-Venezia Giulia"
       },
       "name": {
-        "lang:it_IT": "Pordenone"
+        "lang:it": "Pordenone"
       },
       "parent_id": "Q1250"
     }

--- a/legislative/Q3687387/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687387/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -58,7 +58,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio"
+        "lang:it": "Lazio"
       },
       "parent_id": "Q38"
     },
@@ -83,8 +83,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -107,7 +107,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Frosinone"
+        "lang:it": "Frosinone"
       },
       "parent_id": "Q1282"
     },
@@ -130,7 +130,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Latina"
+        "lang:it": "Latina"
       },
       "parent_id": "Q1282"
     },
@@ -153,7 +153,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Rieti"
+        "lang:it": "Rieti"
       },
       "parent_id": "Q1282"
     },
@@ -176,7 +176,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Viterbo"
+        "lang:it": "Viterbo"
       },
       "parent_id": "Q1282"
     },
@@ -199,7 +199,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Roma"
+        "lang:it": "Roma"
       },
       "parent_id": "Q1282"
     }

--- a/legislative/Q3687390/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687390/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -58,7 +58,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -83,8 +83,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -107,7 +107,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Verona"
+        "lang:it": "Verona"
       },
       "parent_id": "Q1243"
     },
@@ -130,7 +130,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Vicenza"
+        "lang:it": "Vicenza"
       },
       "parent_id": "Q1243"
     },
@@ -153,7 +153,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Belluno"
+        "lang:it": "Belluno"
       },
       "parent_id": "Q1243"
     },
@@ -176,7 +176,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Treviso"
+        "lang:it": "Treviso"
       },
       "parent_id": "Q1243"
     },
@@ -199,7 +199,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Padova"
+        "lang:it": "Padova"
       },
       "parent_id": "Q1243"
     },
@@ -222,7 +222,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Rovigo"
+        "lang:it": "Rovigo"
       },
       "parent_id": "Q1243"
     },
@@ -245,7 +245,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Venezia"
+        "lang:it": "Venezia"
       },
       "parent_id": "Q1243"
     }

--- a/legislative/Q3687391/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687391/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -75,7 +75,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Abruzzo"
+        "lang:it": "Abruzzo"
       },
       "parent_id": "Q38"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -124,7 +124,7 @@
         "lang:en": "Constituency of the Regional Council of Abruzzo"
       },
       "name": {
-        "lang:it_IT": "L'Aquila"
+        "lang:it": "L'Aquila"
       },
       "parent_id": "Q1284"
     },
@@ -147,7 +147,7 @@
         "lang:en": "Constituency of the Regional Council of Abruzzo"
       },
       "name": {
-        "lang:it_IT": "Chieti"
+        "lang:it": "Chieti"
       },
       "parent_id": "Q1284"
     },
@@ -170,7 +170,7 @@
         "lang:en": "Constituency of the Regional Council of Abruzzo"
       },
       "name": {
-        "lang:it_IT": "Pescara"
+        "lang:it": "Pescara"
       },
       "parent_id": "Q1284"
     },
@@ -193,7 +193,7 @@
         "lang:en": "Constituency of the Regional Council of Abruzzo"
       },
       "name": {
-        "lang:it_IT": "Teramo"
+        "lang:it": "Teramo"
       },
       "parent_id": "Q1284"
     }

--- a/legislative/Q3687394/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687394/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -75,7 +75,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria"
+        "lang:it": "Calabria"
       },
       "parent_id": "Q38"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -124,7 +124,7 @@
         "lang:en": "Constituency of the Regional Council of Calabria"
       },
       "name": {
-        "lang:it_IT": "Cosenza"
+        "lang:it": "Cosenza"
       },
       "parent_id": "Q1458"
     },
@@ -147,7 +147,7 @@
         "lang:en": "Constituency of the Regional Council of Calabria"
       },
       "name": {
-        "lang:it_IT": "Catanzaro"
+        "lang:it": "Catanzaro"
       },
       "parent_id": "Q1458"
     },
@@ -170,7 +170,7 @@
         "lang:en": "Constituency of the Regional Council of Calabria"
       },
       "name": {
-        "lang:it_IT": "Crotone"
+        "lang:it": "Crotone"
       },
       "parent_id": "Q1458"
     },
@@ -193,7 +193,7 @@
         "lang:en": "Constituency of the Regional Council of Calabria"
       },
       "name": {
-        "lang:it_IT": "Vibo Valentia"
+        "lang:it": "Vibo Valentia"
       },
       "parent_id": "Q1458"
     },
@@ -216,7 +216,7 @@
         "lang:en": "Constituency of the Regional Council of Calabria"
       },
       "name": {
-        "lang:it_IT": "Reggio di Calabria"
+        "lang:it": "Reggio di Calabria"
       },
       "parent_id": "Q1458"
     }

--- a/legislative/Q3687395/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687395/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -74,7 +74,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia"
+        "lang:it": "Lombardia"
       },
       "parent_id": "Q38"
     },
@@ -99,8 +99,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -123,7 +123,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Varese"
+        "lang:it": "Varese"
       },
       "parent_id": "Q1210"
     },
@@ -146,7 +146,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Como"
+        "lang:it": "Como"
       },
       "parent_id": "Q1210"
     },
@@ -169,7 +169,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Sondrio"
+        "lang:it": "Sondrio"
       },
       "parent_id": "Q1210"
     },
@@ -192,7 +192,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Bergamo"
+        "lang:it": "Bergamo"
       },
       "parent_id": "Q1210"
     },
@@ -215,7 +215,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Brescia"
+        "lang:it": "Brescia"
       },
       "parent_id": "Q1210"
     },
@@ -238,7 +238,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Pavia"
+        "lang:it": "Pavia"
       },
       "parent_id": "Q1210"
     },
@@ -261,7 +261,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Cremona"
+        "lang:it": "Cremona"
       },
       "parent_id": "Q1210"
     },
@@ -284,7 +284,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Mantova"
+        "lang:it": "Mantova"
       },
       "parent_id": "Q1210"
     },
@@ -307,7 +307,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Lecco"
+        "lang:it": "Lecco"
       },
       "parent_id": "Q1210"
     },
@@ -330,7 +330,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Lodi"
+        "lang:it": "Lodi"
       },
       "parent_id": "Q1210"
     },
@@ -353,7 +353,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Monza e della Brianza"
+        "lang:it": "Monza e della Brianza"
       },
       "parent_id": "Q1210"
     },
@@ -376,7 +376,7 @@
         "lang:en": "Constituency of the Regional Council of Lombardy"
       },
       "name": {
-        "lang:it_IT": "Milano"
+        "lang:it": "Milano"
       },
       "parent_id": "Q1210"
     }

--- a/legislative/Q3687397/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687397/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna"
+        "lang:it": "Sardegna"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Sardinia"
       },
       "name": {
-        "lang:it_IT": "Sassari"
+        "lang:it": "Sassari"
       },
       "parent_id": "Q1462"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Sardinia"
       },
       "name": {
-        "lang:it_IT": "Nuoro"
+        "lang:it": "Nuoro"
       },
       "parent_id": "Q1462"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Sardinia"
       },
       "name": {
-        "lang:it_IT": "Oristano"
+        "lang:it": "Oristano"
       },
       "parent_id": "Q1462"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Sardinia"
       },
       "name": {
-        "lang:it_IT": "Cagliari"
+        "lang:it": "Cagliari"
       },
       "parent_id": "Q1462"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Regional Council of Sardinia"
       },
       "name": {
-        "lang:it_IT": "Sud Sardegna"
+        "lang:it": "Sud Sardegna"
       },
       "parent_id": "Q1462"
     }

--- a/legislative/Q3687399/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q3687399/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana"
+        "lang:it": "Toscana"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Massa Carrara"
+        "lang:it": "Massa Carrara"
       },
       "parent_id": "Q1273"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Lucca"
+        "lang:it": "Lucca"
       },
       "parent_id": "Q1273"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Pistoia"
+        "lang:it": "Pistoia"
       },
       "parent_id": "Q1273"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Livorno"
+        "lang:it": "Livorno"
       },
       "parent_id": "Q1273"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Pisa"
+        "lang:it": "Pisa"
       },
       "parent_id": "Q1273"
     },
@@ -190,7 +190,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Arezzo"
+        "lang:it": "Arezzo"
       },
       "parent_id": "Q1273"
     },
@@ -213,7 +213,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Siena"
+        "lang:it": "Siena"
       },
       "parent_id": "Q1273"
     },
@@ -236,7 +236,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Grosseto"
+        "lang:it": "Grosseto"
       },
       "parent_id": "Q1273"
     },
@@ -259,7 +259,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Prato"
+        "lang:it": "Prato"
       },
       "parent_id": "Q1273"
     },
@@ -282,7 +282,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Firenze"
+        "lang:it": "Firenze"
       },
       "parent_id": "Q1273"
     }

--- a/legislative/Q48617968/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q48617968/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -176,7 +176,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio"
+        "lang:it": "Lazio"
       },
       "parent_id": "Q38"
     },
@@ -201,7 +201,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Roma"
+        "lang:it": "Roma"
       },
       "parent_id": "Q47909105"
     },
@@ -226,8 +226,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -250,7 +250,7 @@
         "lang:en": "Constituency of the Regional Council of Lazio"
       },
       "name": {
-        "lang:it_IT": "Roma"
+        "lang:it": "Roma"
       },
       "parent_id": "Q1282"
     }

--- a/legislative/Q50182554/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50182554/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia"
+        "lang:it": "Puglia"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Bari"
+        "lang:it": "Bari"
       },
       "parent_id": "Q47904406"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Regional Council of Apulia"
       },
       "name": {
-        "lang:it_IT": "Bari"
+        "lang:it": "Bari"
       },
       "parent_id": "Q1447"
     }

--- a/legislative/Q50185924/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50185924/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna"
+        "lang:it": "Emilia-Romagna"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Bologna"
+        "lang:it": "Bologna"
       },
       "parent_id": "Q47998557"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Bologna"
+        "lang:it": "Bologna"
       },
       "parent_id": "Q1263"
     }

--- a/legislative/Q50187717/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50187717/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Catania"
+        "lang:it": "Catania"
       },
       "parent_id": "Q48006727"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Catania"
+        "lang:it": "Catania"
       },
       "parent_id": "Q1460"
     }

--- a/legislative/Q50188656/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50188656/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana"
+        "lang:it": "Toscana"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Firenze"
+        "lang:it": "Firenze"
       },
       "parent_id": "Q47998855"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Regional Council of Tuscany"
       },
       "name": {
-        "lang:it_IT": "Firenze"
+        "lang:it": "Firenze"
       },
       "parent_id": "Q1273"
     }

--- a/legislative/Q50189268/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50189268/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria"
+        "lang:it": "Liguria"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Genova"
+        "lang:it": "Genova"
       },
       "parent_id": "Q47998323"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Regional Council of Liguria"
       },
       "name": {
-        "lang:it_IT": "Genova"
+        "lang:it": "Genova"
       },
       "parent_id": "Q1256"
     }

--- a/legislative/Q50190089/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50190089/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -58,7 +58,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania"
+        "lang:it": "Campania"
       },
       "parent_id": "Q38"
     },
@@ -83,7 +83,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Napoli"
+        "lang:it": "Napoli"
       },
       "parent_id": "Q47998998"
     },
@@ -108,8 +108,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -132,7 +132,7 @@
         "lang:en": "Constituency of the Regional Council of Campania"
       },
       "name": {
-        "lang:it_IT": "Napoli"
+        "lang:it": "Napoli"
       },
       "parent_id": "Q1438"
     }

--- a/legislative/Q50190204/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50190204/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Palermo"
+        "lang:it": "Palermo"
       },
       "parent_id": "Q48006247"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Sicilian Regional Assembly"
       },
       "name": {
-        "lang:it_IT": "Palermo"
+        "lang:it": "Palermo"
       },
       "parent_id": "Q1460"
     }

--- a/legislative/Q50247531/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50247531/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte"
+        "lang:it": "Piemonte"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Piedmont"
       },
       "name": {
-        "lang:it_IT": "Torino"
+        "lang:it": "Torino"
       },
       "parent_id": "Q1216"
     },
@@ -100,7 +100,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Torino"
+        "lang:it": "Torino"
       },
       "parent_id": "Q47997465"
     }

--- a/legislative/Q50248378/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50248378/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Venezia"
+        "lang:it": "Venezia"
       },
       "parent_id": "Q1243"
     },
@@ -100,7 +100,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Venezia"
+        "lang:it": "Venezia"
       },
       "parent_id": "Q47998078"
     }

--- a/legislative/Q50251292/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q50251292/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -51,7 +51,7 @@
         "lang:en": "comune of Italy"
       },
       "name": {
-        "lang:it_IT": "Verona"
+        "lang:it": "Verona"
       },
       "parent_id": "Q47928281"
     },
@@ -76,8 +76,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "Constituency of the Regional Council of Veneto"
       },
       "name": {
-        "lang:it_IT": "Verona"
+        "lang:it": "Verona"
       },
       "parent_id": "Q1243"
     }

--- a/legislative/Q633872/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q633872/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -3161,7 +3161,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia"
+        "lang:it": "Lombardia"
       },
       "parent_id": "Q38"
     },
@@ -3185,7 +3185,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte"
+        "lang:it": "Piemonte"
       },
       "parent_id": "Q38"
     },
@@ -3209,7 +3209,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Valle d'Aosta"
+        "lang:it": "Valle d'Aosta"
       },
       "parent_id": "Q38"
     },
@@ -3233,7 +3233,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige"
+        "lang:it": "Trentino-Alto Adige"
       },
       "parent_id": "Q38"
     },
@@ -3257,7 +3257,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -3281,7 +3281,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia"
+        "lang:it": "Friuli-Venezia Giulia"
       },
       "parent_id": "Q38"
     },
@@ -3305,7 +3305,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria"
+        "lang:it": "Liguria"
       },
       "parent_id": "Q38"
     },
@@ -3329,7 +3329,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna"
+        "lang:it": "Emilia-Romagna"
       },
       "parent_id": "Q38"
     },
@@ -3353,7 +3353,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana"
+        "lang:it": "Toscana"
       },
       "parent_id": "Q38"
     },
@@ -3377,7 +3377,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche"
+        "lang:it": "Marche"
       },
       "parent_id": "Q38"
     },
@@ -3401,7 +3401,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Umbria"
+        "lang:it": "Umbria"
       },
       "parent_id": "Q38"
     },
@@ -3425,7 +3425,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio"
+        "lang:it": "Lazio"
       },
       "parent_id": "Q38"
     },
@@ -3449,7 +3449,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Abruzzo"
+        "lang:it": "Abruzzo"
       },
       "parent_id": "Q38"
     },
@@ -3473,7 +3473,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania"
+        "lang:it": "Campania"
       },
       "parent_id": "Q38"
     },
@@ -3497,7 +3497,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Molise"
+        "lang:it": "Molise"
       },
       "parent_id": "Q38"
     },
@@ -3521,7 +3521,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia"
+        "lang:it": "Puglia"
       },
       "parent_id": "Q38"
     },
@@ -3545,7 +3545,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Basilicata"
+        "lang:it": "Basilicata"
       },
       "parent_id": "Q38"
     },
@@ -3569,7 +3569,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria"
+        "lang:it": "Calabria"
       },
       "parent_id": "Q38"
     },
@@ -3593,7 +3593,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -3617,7 +3617,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna"
+        "lang:it": "Sardegna"
       },
       "parent_id": "Q38"
     },
@@ -3642,8 +3642,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -3667,7 +3667,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 01"
+        "lang:it": "Piemonte - 01"
       },
       "parent_id": "Q1216"
     },
@@ -3691,7 +3691,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 02"
+        "lang:it": "Piemonte - 02"
       },
       "parent_id": "Q1216"
     },
@@ -3715,7 +3715,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 03"
+        "lang:it": "Piemonte - 03"
       },
       "parent_id": "Q1216"
     },
@@ -3739,7 +3739,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Valle d'Aosta/Vallée d'Aoste - 01"
+        "lang:it": "Valle d'Aosta/Vallée d'Aoste - 01"
       },
       "parent_id": "Q1222"
     },
@@ -3763,7 +3763,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 01"
+        "lang:it": "Lombardia - 01"
       },
       "parent_id": "Q1210"
     },
@@ -3787,7 +3787,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 02"
+        "lang:it": "Lombardia - 02"
       },
       "parent_id": "Q1210"
     },
@@ -3811,7 +3811,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 03"
+        "lang:it": "Lombardia - 03"
       },
       "parent_id": "Q1210"
     },
@@ -3835,7 +3835,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 01"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 01"
       },
       "parent_id": "Q1237"
     },
@@ -3859,7 +3859,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 02"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 02"
       },
       "parent_id": "Q1237"
     },
@@ -3883,7 +3883,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 03"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 03"
       },
       "parent_id": "Q1237"
     },
@@ -3907,7 +3907,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 04"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 04"
       },
       "parent_id": "Q1237"
     },
@@ -3931,7 +3931,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 05"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 05"
       },
       "parent_id": "Q1237"
     },
@@ -3955,7 +3955,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 06"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 06"
       },
       "parent_id": "Q1237"
     },
@@ -3979,7 +3979,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 01"
+        "lang:it": "Veneto - 01"
       },
       "parent_id": "Q1243"
     },
@@ -4003,7 +4003,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 02"
+        "lang:it": "Veneto - 02"
       },
       "parent_id": "Q1243"
     },
@@ -4027,7 +4027,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 01"
+        "lang:it": "Friuli-Venezia Giulia - 01"
       },
       "parent_id": "Q1250"
     },
@@ -4051,7 +4051,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 02"
+        "lang:it": "Friuli-Venezia Giulia - 02"
       },
       "parent_id": "Q1250"
     },
@@ -4075,7 +4075,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria - 01"
+        "lang:it": "Liguria - 01"
       },
       "parent_id": "Q1256"
     },
@@ -4099,7 +4099,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria - 02"
+        "lang:it": "Liguria - 02"
       },
       "parent_id": "Q1256"
     },
@@ -4123,7 +4123,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria - 03"
+        "lang:it": "Liguria - 03"
       },
       "parent_id": "Q1256"
     },
@@ -4147,7 +4147,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 01"
+        "lang:it": "Emilia-Romagna - 01"
       },
       "parent_id": "Q1263"
     },
@@ -4171,7 +4171,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 02"
+        "lang:it": "Emilia-Romagna - 02"
       },
       "parent_id": "Q1263"
     },
@@ -4195,7 +4195,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 03"
+        "lang:it": "Emilia-Romagna - 03"
       },
       "parent_id": "Q1263"
     },
@@ -4219,7 +4219,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 04"
+        "lang:it": "Emilia-Romagna - 04"
       },
       "parent_id": "Q1263"
     },
@@ -4243,7 +4243,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 05"
+        "lang:it": "Emilia-Romagna - 05"
       },
       "parent_id": "Q1263"
     },
@@ -4267,7 +4267,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 06"
+        "lang:it": "Emilia-Romagna - 06"
       },
       "parent_id": "Q1263"
     },
@@ -4291,7 +4291,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 07"
+        "lang:it": "Emilia-Romagna - 07"
       },
       "parent_id": "Q1263"
     },
@@ -4315,7 +4315,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 08"
+        "lang:it": "Emilia-Romagna - 08"
       },
       "parent_id": "Q1263"
     },
@@ -4339,7 +4339,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 01"
+        "lang:it": "Toscana - 01"
       },
       "parent_id": "Q1273"
     },
@@ -4363,7 +4363,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 02"
+        "lang:it": "Toscana - 02"
       },
       "parent_id": "Q1273"
     },
@@ -4387,7 +4387,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 03"
+        "lang:it": "Toscana - 03"
       },
       "parent_id": "Q1273"
     },
@@ -4411,7 +4411,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 04"
+        "lang:it": "Toscana - 04"
       },
       "parent_id": "Q1273"
     },
@@ -4435,7 +4435,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 05"
+        "lang:it": "Toscana - 05"
       },
       "parent_id": "Q1273"
     },
@@ -4459,7 +4459,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 06"
+        "lang:it": "Toscana - 06"
       },
       "parent_id": "Q1273"
     },
@@ -4483,7 +4483,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana - 07"
+        "lang:it": "Toscana - 07"
       },
       "parent_id": "Q1273"
     },
@@ -4507,7 +4507,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Umbria - 01"
+        "lang:it": "Umbria - 01"
       },
       "parent_id": "Q1280"
     },
@@ -4531,7 +4531,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Umbria - 02"
+        "lang:it": "Umbria - 02"
       },
       "parent_id": "Q1280"
     },
@@ -4555,7 +4555,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche - 01"
+        "lang:it": "Marche - 01"
       },
       "parent_id": "Q1279"
     },
@@ -4579,7 +4579,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche - 02"
+        "lang:it": "Marche - 02"
       },
       "parent_id": "Q1279"
     },
@@ -4603,7 +4603,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche - 03"
+        "lang:it": "Marche - 03"
       },
       "parent_id": "Q1279"
     },
@@ -4627,7 +4627,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 01"
+        "lang:it": "Lazio - 01"
       },
       "parent_id": "Q1282"
     },
@@ -4651,7 +4651,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 02"
+        "lang:it": "Lazio - 02"
       },
       "parent_id": "Q1282"
     },
@@ -4675,7 +4675,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 01"
+        "lang:it": "Abruzzo - 01"
       },
       "parent_id": "Q1284"
     },
@@ -4699,7 +4699,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 02"
+        "lang:it": "Abruzzo - 02"
       },
       "parent_id": "Q1284"
     },
@@ -4723,7 +4723,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Molise - 01"
+        "lang:it": "Molise - 01"
       },
       "parent_id": "Q1443"
     },
@@ -4747,7 +4747,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 01"
+        "lang:it": "Campania - 01"
       },
       "parent_id": "Q1438"
     },
@@ -4771,7 +4771,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 02"
+        "lang:it": "Campania - 02"
       },
       "parent_id": "Q1438"
     },
@@ -4795,7 +4795,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 01"
+        "lang:it": "Puglia - 01"
       },
       "parent_id": "Q1447"
     },
@@ -4819,7 +4819,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 02"
+        "lang:it": "Puglia - 02"
       },
       "parent_id": "Q1447"
     },
@@ -4843,7 +4843,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 03"
+        "lang:it": "Puglia - 03"
       },
       "parent_id": "Q1447"
     },
@@ -4867,7 +4867,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 04"
+        "lang:it": "Puglia - 04"
       },
       "parent_id": "Q1447"
     },
@@ -4891,7 +4891,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 05"
+        "lang:it": "Puglia - 05"
       },
       "parent_id": "Q1447"
     },
@@ -4915,7 +4915,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 06"
+        "lang:it": "Puglia - 06"
       },
       "parent_id": "Q1447"
     },
@@ -4939,7 +4939,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 07"
+        "lang:it": "Puglia - 07"
       },
       "parent_id": "Q1447"
     },
@@ -4963,7 +4963,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia - 08"
+        "lang:it": "Puglia - 08"
       },
       "parent_id": "Q1447"
     },
@@ -4987,7 +4987,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Basilicata - 01"
+        "lang:it": "Basilicata - 01"
       },
       "parent_id": "Q1452"
     },
@@ -5011,7 +5011,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria - 01"
+        "lang:it": "Calabria - 01"
       },
       "parent_id": "Q1458"
     },
@@ -5035,7 +5035,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria - 02"
+        "lang:it": "Calabria - 02"
       },
       "parent_id": "Q1458"
     },
@@ -5059,7 +5059,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria - 03"
+        "lang:it": "Calabria - 03"
       },
       "parent_id": "Q1458"
     },
@@ -5083,7 +5083,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria - 04"
+        "lang:it": "Calabria - 04"
       },
       "parent_id": "Q1458"
     },
@@ -5107,7 +5107,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 01"
+        "lang:it": "Sardegna - 01"
       },
       "parent_id": "Q1462"
     },
@@ -5131,7 +5131,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 02"
+        "lang:it": "Sardegna - 02"
       },
       "parent_id": "Q1462"
     },
@@ -5155,7 +5155,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 03"
+        "lang:it": "Sardegna - 03"
       },
       "parent_id": "Q1462"
     },
@@ -5179,7 +5179,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 04"
+        "lang:it": "Piemonte - 04"
       },
       "parent_id": "Q1216"
     },
@@ -5203,7 +5203,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 05"
+        "lang:it": "Piemonte - 05"
       },
       "parent_id": "Q1216"
     },
@@ -5227,7 +5227,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 06"
+        "lang:it": "Piemonte - 06"
       },
       "parent_id": "Q1216"
     },
@@ -5251,7 +5251,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 07"
+        "lang:it": "Piemonte - 07"
       },
       "parent_id": "Q1216"
     },
@@ -5275,7 +5275,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte - 08"
+        "lang:it": "Piemonte - 08"
       },
       "parent_id": "Q1216"
     },
@@ -5299,7 +5299,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 04"
+        "lang:it": "Lombardia - 04"
       },
       "parent_id": "Q1210"
     },
@@ -5323,7 +5323,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 05"
+        "lang:it": "Lombardia - 05"
       },
       "parent_id": "Q1210"
     },
@@ -5347,7 +5347,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 06"
+        "lang:it": "Lombardia - 06"
       },
       "parent_id": "Q1210"
     },
@@ -5371,7 +5371,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 07"
+        "lang:it": "Lombardia - 07"
       },
       "parent_id": "Q1210"
     },
@@ -5395,7 +5395,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 08"
+        "lang:it": "Lombardia - 08"
       },
       "parent_id": "Q1210"
     },
@@ -5419,7 +5419,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 09"
+        "lang:it": "Lombardia - 09"
       },
       "parent_id": "Q1210"
     },
@@ -5443,7 +5443,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 10"
+        "lang:it": "Lombardia - 10"
       },
       "parent_id": "Q1210"
     },
@@ -5467,7 +5467,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 11"
+        "lang:it": "Lombardia - 11"
       },
       "parent_id": "Q1210"
     },
@@ -5491,7 +5491,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 12"
+        "lang:it": "Lombardia - 12"
       },
       "parent_id": "Q1210"
     },
@@ -5515,7 +5515,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 13"
+        "lang:it": "Lombardia - 13"
       },
       "parent_id": "Q1210"
     },
@@ -5539,7 +5539,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 14"
+        "lang:it": "Lombardia - 14"
       },
       "parent_id": "Q1210"
     },
@@ -5563,7 +5563,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 15"
+        "lang:it": "Lombardia - 15"
       },
       "parent_id": "Q1210"
     },
@@ -5587,7 +5587,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 16"
+        "lang:it": "Lombardia - 16"
       },
       "parent_id": "Q1210"
     },
@@ -5611,7 +5611,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 17"
+        "lang:it": "Lombardia - 17"
       },
       "parent_id": "Q1210"
     },
@@ -5635,7 +5635,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia - 18"
+        "lang:it": "Lombardia - 18"
       },
       "parent_id": "Q1210"
     },
@@ -5659,7 +5659,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 03"
+        "lang:it": "Veneto - 03"
       },
       "parent_id": "Q1243"
     },
@@ -5683,7 +5683,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 04"
+        "lang:it": "Veneto - 04"
       },
       "parent_id": "Q1243"
     },
@@ -5707,7 +5707,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 05"
+        "lang:it": "Veneto - 05"
       },
       "parent_id": "Q1243"
     },
@@ -5731,7 +5731,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 06"
+        "lang:it": "Veneto - 06"
       },
       "parent_id": "Q1243"
     },
@@ -5755,7 +5755,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 07"
+        "lang:it": "Veneto - 07"
       },
       "parent_id": "Q1243"
     },
@@ -5779,7 +5779,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 08"
+        "lang:it": "Veneto - 08"
       },
       "parent_id": "Q1243"
     },
@@ -5803,7 +5803,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto - 09"
+        "lang:it": "Veneto - 09"
       },
       "parent_id": "Q1243"
     },
@@ -5827,7 +5827,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 03"
+        "lang:it": "Lazio - 03"
       },
       "parent_id": "Q1282"
     },
@@ -5851,7 +5851,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 04"
+        "lang:it": "Lazio - 04"
       },
       "parent_id": "Q1282"
     },
@@ -5875,7 +5875,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 05"
+        "lang:it": "Lazio - 05"
       },
       "parent_id": "Q1282"
     },
@@ -5899,7 +5899,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 06"
+        "lang:it": "Lazio - 06"
       },
       "parent_id": "Q1282"
     },
@@ -5923,7 +5923,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 07"
+        "lang:it": "Lazio - 07"
       },
       "parent_id": "Q1282"
     },
@@ -5947,7 +5947,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 08"
+        "lang:it": "Lazio - 08"
       },
       "parent_id": "Q1282"
     },
@@ -5971,7 +5971,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 09"
+        "lang:it": "Lazio - 09"
       },
       "parent_id": "Q1282"
     },
@@ -5995,7 +5995,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio - 10"
+        "lang:it": "Lazio - 10"
       },
       "parent_id": "Q1282"
     },
@@ -6019,7 +6019,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 03"
+        "lang:it": "Campania - 03"
       },
       "parent_id": "Q1438"
     },
@@ -6043,7 +6043,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 04"
+        "lang:it": "Campania - 04"
       },
       "parent_id": "Q1438"
     },
@@ -6067,7 +6067,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 05"
+        "lang:it": "Campania - 05"
       },
       "parent_id": "Q1438"
     },
@@ -6091,7 +6091,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 06"
+        "lang:it": "Campania - 06"
       },
       "parent_id": "Q1438"
     },
@@ -6115,7 +6115,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 07"
+        "lang:it": "Campania - 07"
       },
       "parent_id": "Q1438"
     },
@@ -6139,7 +6139,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 08"
+        "lang:it": "Campania - 08"
       },
       "parent_id": "Q1438"
     },
@@ -6163,7 +6163,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 09"
+        "lang:it": "Campania - 09"
       },
       "parent_id": "Q1438"
     },
@@ -6187,7 +6187,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 10"
+        "lang:it": "Campania - 10"
       },
       "parent_id": "Q1438"
     },
@@ -6211,7 +6211,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania - 11"
+        "lang:it": "Campania - 11"
       },
       "parent_id": "Q1438"
     },
@@ -6235,7 +6235,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 01"
+        "lang:it": "Sicilia - 01"
       },
       "parent_id": "Q1460"
     },
@@ -6259,7 +6259,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 02"
+        "lang:it": "Sicilia - 02"
       },
       "parent_id": "Q1460"
     },
@@ -6283,7 +6283,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 03"
+        "lang:it": "Sicilia - 03"
       },
       "parent_id": "Q1460"
     },
@@ -6307,7 +6307,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 04"
+        "lang:it": "Sicilia - 04"
       },
       "parent_id": "Q1460"
     },
@@ -6331,7 +6331,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 05"
+        "lang:it": "Sicilia - 05"
       },
       "parent_id": "Q1460"
     },
@@ -6355,7 +6355,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 06"
+        "lang:it": "Sicilia - 06"
       },
       "parent_id": "Q1460"
     },
@@ -6379,7 +6379,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 07"
+        "lang:it": "Sicilia - 07"
       },
       "parent_id": "Q1460"
     },
@@ -6403,7 +6403,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 08"
+        "lang:it": "Sicilia - 08"
       },
       "parent_id": "Q1460"
     },
@@ -6427,7 +6427,7 @@
         "lang:en": "uninominal constituency of the Senate of the Republic of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia - 09"
+        "lang:it": "Sicilia - 09"
       },
       "parent_id": "Q1460"
     }

--- a/legislative/Q7309036/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q7309036/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,7 +26,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna"
+        "lang:it": "Emilia-Romagna"
       },
       "parent_id": "Q38"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -75,7 +75,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Bologna"
+        "lang:it": "Bologna"
       },
       "parent_id": "Q1263"
     },
@@ -98,7 +98,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Ferrara"
+        "lang:it": "Ferrara"
       },
       "parent_id": "Q1263"
     },
@@ -121,7 +121,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Forli'-Cesena"
+        "lang:it": "Forli'-Cesena"
       },
       "parent_id": "Q1263"
     },
@@ -144,7 +144,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Modena"
+        "lang:it": "Modena"
       },
       "parent_id": "Q1263"
     },
@@ -167,7 +167,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Parma"
+        "lang:it": "Parma"
       },
       "parent_id": "Q1263"
     },
@@ -190,7 +190,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Piacenza"
+        "lang:it": "Piacenza"
       },
       "parent_id": "Q1263"
     },
@@ -213,7 +213,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Ravenna"
+        "lang:it": "Ravenna"
       },
       "parent_id": "Q1263"
     },
@@ -236,7 +236,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Reggio nell'Emilia"
+        "lang:it": "Reggio nell'Emilia"
       },
       "parent_id": "Q1263"
     },
@@ -259,7 +259,7 @@
         "lang:en": "Constituency of the Legislative Assembly of Emilia-Romagna"
       },
       "name": {
-        "lang:it_IT": "Rimini"
+        "lang:it": "Rimini"
       },
       "parent_id": "Q1263"
     }

--- a/legislative/Q841424/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q841424/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -57224,7 +57224,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lombardia"
+        "lang:it": "Lombardia"
       },
       "parent_id": "Q38"
     },
@@ -57248,7 +57248,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Piemonte"
+        "lang:it": "Piemonte"
       },
       "parent_id": "Q38"
     },
@@ -57272,7 +57272,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Valle d'Aosta"
+        "lang:it": "Valle d'Aosta"
       },
       "parent_id": "Q38"
     },
@@ -57296,7 +57296,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige"
+        "lang:it": "Trentino-Alto Adige"
       },
       "parent_id": "Q38"
     },
@@ -57320,7 +57320,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Veneto"
+        "lang:it": "Veneto"
       },
       "parent_id": "Q38"
     },
@@ -57344,7 +57344,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia"
+        "lang:it": "Friuli-Venezia Giulia"
       },
       "parent_id": "Q38"
     },
@@ -57368,7 +57368,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Liguria"
+        "lang:it": "Liguria"
       },
       "parent_id": "Q38"
     },
@@ -57392,7 +57392,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna"
+        "lang:it": "Emilia-Romagna"
       },
       "parent_id": "Q38"
     },
@@ -57416,7 +57416,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Toscana"
+        "lang:it": "Toscana"
       },
       "parent_id": "Q38"
     },
@@ -57440,7 +57440,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Marche"
+        "lang:it": "Marche"
       },
       "parent_id": "Q38"
     },
@@ -57464,7 +57464,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Umbria"
+        "lang:it": "Umbria"
       },
       "parent_id": "Q38"
     },
@@ -57488,7 +57488,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Lazio"
+        "lang:it": "Lazio"
       },
       "parent_id": "Q38"
     },
@@ -57512,7 +57512,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Abruzzo"
+        "lang:it": "Abruzzo"
       },
       "parent_id": "Q38"
     },
@@ -57536,7 +57536,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Campania"
+        "lang:it": "Campania"
       },
       "parent_id": "Q38"
     },
@@ -57560,7 +57560,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Molise"
+        "lang:it": "Molise"
       },
       "parent_id": "Q38"
     },
@@ -57584,7 +57584,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Puglia"
+        "lang:it": "Puglia"
       },
       "parent_id": "Q38"
     },
@@ -57608,7 +57608,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Basilicata"
+        "lang:it": "Basilicata"
       },
       "parent_id": "Q38"
     },
@@ -57632,7 +57632,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Calabria"
+        "lang:it": "Calabria"
       },
       "parent_id": "Q38"
     },
@@ -57656,7 +57656,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sicilia"
+        "lang:it": "Sicilia"
       },
       "parent_id": "Q38"
     },
@@ -57680,7 +57680,7 @@
         "lang:en": "region of Italy"
       },
       "name": {
-        "lang:it_IT": "Sardegna"
+        "lang:it": "Sardegna"
       },
       "parent_id": "Q38"
     },
@@ -57705,8 +57705,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:it_IT": "Italia",
-        "lang:en_US": "Italy"
+        "lang:it": "Italia",
+        "lang:en": "Italy"
       },
       "parent_id": null
     },
@@ -57730,7 +57730,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 01"
+        "lang:it": "Abruzzo - 01"
       },
       "parent_id": "Q1284"
     },
@@ -57754,7 +57754,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 02"
+        "lang:it": "Abruzzo - 02"
       },
       "parent_id": "Q1284"
     },
@@ -57778,7 +57778,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 03"
+        "lang:it": "Abruzzo - 03"
       },
       "parent_id": "Q1284"
     },
@@ -57802,7 +57802,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 01"
+        "lang:it": "Piemonte 1 - 01"
       },
       "parent_id": "Q1216"
     },
@@ -57826,7 +57826,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 02"
+        "lang:it": "Piemonte 1 - 02"
       },
       "parent_id": "Q1216"
     },
@@ -57850,7 +57850,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 03"
+        "lang:it": "Piemonte 1 - 03"
       },
       "parent_id": "Q1216"
     },
@@ -57874,7 +57874,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 04"
+        "lang:it": "Piemonte 1 - 04"
       },
       "parent_id": "Q1216"
     },
@@ -57898,7 +57898,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 05"
+        "lang:it": "Piemonte 1 - 05"
       },
       "parent_id": "Q1216"
     },
@@ -57922,7 +57922,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 06"
+        "lang:it": "Piemonte 1 - 06"
       },
       "parent_id": "Q1216"
     },
@@ -57946,7 +57946,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 07"
+        "lang:it": "Piemonte 1 - 07"
       },
       "parent_id": "Q1216"
     },
@@ -57970,7 +57970,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 08"
+        "lang:it": "Piemonte 1 - 08"
       },
       "parent_id": "Q1216"
     },
@@ -57994,7 +57994,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 1 - 09"
+        "lang:it": "Piemonte 1 - 09"
       },
       "parent_id": "Q1216"
     },
@@ -58018,7 +58018,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 01"
+        "lang:it": "Piemonte 2 - 01"
       },
       "parent_id": "Q1216"
     },
@@ -58042,7 +58042,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 02"
+        "lang:it": "Piemonte 2 - 02"
       },
       "parent_id": "Q1216"
     },
@@ -58066,7 +58066,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 03"
+        "lang:it": "Piemonte 2 - 03"
       },
       "parent_id": "Q1216"
     },
@@ -58090,7 +58090,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 04"
+        "lang:it": "Piemonte 2 - 04"
       },
       "parent_id": "Q1216"
     },
@@ -58114,7 +58114,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 05"
+        "lang:it": "Piemonte 2 - 05"
       },
       "parent_id": "Q1216"
     },
@@ -58138,7 +58138,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 06"
+        "lang:it": "Piemonte 2 - 06"
       },
       "parent_id": "Q1216"
     },
@@ -58162,7 +58162,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 07"
+        "lang:it": "Piemonte 2 - 07"
       },
       "parent_id": "Q1216"
     },
@@ -58186,7 +58186,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Piemonte 2 - 08"
+        "lang:it": "Piemonte 2 - 08"
       },
       "parent_id": "Q1216"
     },
@@ -58210,7 +58210,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Valle d'Aosta/Vallée d'Aoste - 01"
+        "lang:it": "Valle d'Aosta/Vallée d'Aoste - 01"
       },
       "parent_id": "Q1222"
     },
@@ -58234,7 +58234,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 01"
+        "lang:it": "Lombardia 1 - 01"
       },
       "parent_id": "Q1210"
     },
@@ -58258,7 +58258,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 02"
+        "lang:it": "Lombardia 1 - 02"
       },
       "parent_id": "Q1210"
     },
@@ -58282,7 +58282,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 03"
+        "lang:it": "Lombardia 1 - 03"
       },
       "parent_id": "Q1210"
     },
@@ -58306,7 +58306,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 04"
+        "lang:it": "Lombardia 1 - 04"
       },
       "parent_id": "Q1210"
     },
@@ -58330,7 +58330,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 05"
+        "lang:it": "Lombardia 1 - 05"
       },
       "parent_id": "Q1210"
     },
@@ -58354,7 +58354,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 06"
+        "lang:it": "Lombardia 1 - 06"
       },
       "parent_id": "Q1210"
     },
@@ -58378,7 +58378,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 07"
+        "lang:it": "Lombardia 1 - 07"
       },
       "parent_id": "Q1210"
     },
@@ -58402,7 +58402,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 08"
+        "lang:it": "Lombardia 1 - 08"
       },
       "parent_id": "Q1210"
     },
@@ -58426,7 +58426,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 09"
+        "lang:it": "Lombardia 1 - 09"
       },
       "parent_id": "Q1210"
     },
@@ -58450,7 +58450,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 10"
+        "lang:it": "Lombardia 1 - 10"
       },
       "parent_id": "Q1210"
     },
@@ -58474,7 +58474,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 11"
+        "lang:it": "Lombardia 1 - 11"
       },
       "parent_id": "Q1210"
     },
@@ -58498,7 +58498,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 12"
+        "lang:it": "Lombardia 1 - 12"
       },
       "parent_id": "Q1210"
     },
@@ -58522,7 +58522,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 13"
+        "lang:it": "Lombardia 1 - 13"
       },
       "parent_id": "Q1210"
     },
@@ -58546,7 +58546,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 14"
+        "lang:it": "Lombardia 1 - 14"
       },
       "parent_id": "Q1210"
     },
@@ -58570,7 +58570,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 1 - 15"
+        "lang:it": "Lombardia 1 - 15"
       },
       "parent_id": "Q1210"
     },
@@ -58594,7 +58594,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 01"
+        "lang:it": "Lombardia 2 - 01"
       },
       "parent_id": "Q1210"
     },
@@ -58618,7 +58618,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 02"
+        "lang:it": "Lombardia 2 - 02"
       },
       "parent_id": "Q1210"
     },
@@ -58642,7 +58642,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 03"
+        "lang:it": "Lombardia 2 - 03"
       },
       "parent_id": "Q1210"
     },
@@ -58666,7 +58666,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 04"
+        "lang:it": "Lombardia 2 - 04"
       },
       "parent_id": "Q1210"
     },
@@ -58690,7 +58690,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 05"
+        "lang:it": "Lombardia 2 - 05"
       },
       "parent_id": "Q1210"
     },
@@ -58714,7 +58714,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 06"
+        "lang:it": "Lombardia 2 - 06"
       },
       "parent_id": "Q1210"
     },
@@ -58738,7 +58738,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 07"
+        "lang:it": "Lombardia 2 - 07"
       },
       "parent_id": "Q1210"
     },
@@ -58762,7 +58762,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 2 - 08"
+        "lang:it": "Lombardia 2 - 08"
       },
       "parent_id": "Q1210"
     },
@@ -58786,7 +58786,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 01"
+        "lang:it": "Lombardia 3 - 01"
       },
       "parent_id": "Q1210"
     },
@@ -58810,7 +58810,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 02"
+        "lang:it": "Lombardia 3 - 02"
       },
       "parent_id": "Q1210"
     },
@@ -58834,7 +58834,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 03"
+        "lang:it": "Lombardia 3 - 03"
       },
       "parent_id": "Q1210"
     },
@@ -58858,7 +58858,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 04"
+        "lang:it": "Lombardia 3 - 04"
       },
       "parent_id": "Q1210"
     },
@@ -58882,7 +58882,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 05"
+        "lang:it": "Lombardia 3 - 05"
       },
       "parent_id": "Q1210"
     },
@@ -58906,7 +58906,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 06"
+        "lang:it": "Lombardia 3 - 06"
       },
       "parent_id": "Q1210"
     },
@@ -58930,7 +58930,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 07"
+        "lang:it": "Lombardia 3 - 07"
       },
       "parent_id": "Q1210"
     },
@@ -58954,7 +58954,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 3 - 08"
+        "lang:it": "Lombardia 3 - 08"
       },
       "parent_id": "Q1210"
     },
@@ -58978,7 +58978,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 4 - 01"
+        "lang:it": "Lombardia 4 - 01"
       },
       "parent_id": "Q1210"
     },
@@ -59002,7 +59002,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 4 - 02"
+        "lang:it": "Lombardia 4 - 02"
       },
       "parent_id": "Q1210"
     },
@@ -59026,7 +59026,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 4 - 03"
+        "lang:it": "Lombardia 4 - 03"
       },
       "parent_id": "Q1210"
     },
@@ -59050,7 +59050,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 4 - 04"
+        "lang:it": "Lombardia 4 - 04"
       },
       "parent_id": "Q1210"
     },
@@ -59074,7 +59074,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 4 - 05"
+        "lang:it": "Lombardia 4 - 05"
       },
       "parent_id": "Q1210"
     },
@@ -59098,7 +59098,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lombardia 4 - 06"
+        "lang:it": "Lombardia 4 - 06"
       },
       "parent_id": "Q1210"
     },
@@ -59122,7 +59122,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 01"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 01"
       },
       "parent_id": "Q1237"
     },
@@ -59146,7 +59146,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 02"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 02"
       },
       "parent_id": "Q1237"
     },
@@ -59170,7 +59170,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 03"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 03"
       },
       "parent_id": "Q1237"
     },
@@ -59194,7 +59194,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 04"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 04"
       },
       "parent_id": "Q1237"
     },
@@ -59218,7 +59218,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 05"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 05"
       },
       "parent_id": "Q1237"
     },
@@ -59242,7 +59242,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Trentino-Alto Adige/Südtirol - 06"
+        "lang:it": "Trentino-Alto Adige/Südtirol - 06"
       },
       "parent_id": "Q1237"
     },
@@ -59266,7 +59266,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 01"
+        "lang:it": "Veneto 1 - 01"
       },
       "parent_id": "Q1243"
     },
@@ -59290,7 +59290,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 02"
+        "lang:it": "Veneto 1 - 02"
       },
       "parent_id": "Q1243"
     },
@@ -59314,7 +59314,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 03"
+        "lang:it": "Veneto 1 - 03"
       },
       "parent_id": "Q1243"
     },
@@ -59338,7 +59338,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 04"
+        "lang:it": "Veneto 1 - 04"
       },
       "parent_id": "Q1243"
     },
@@ -59362,7 +59362,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 05"
+        "lang:it": "Veneto 1 - 05"
       },
       "parent_id": "Q1243"
     },
@@ -59386,7 +59386,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 06"
+        "lang:it": "Veneto 1 - 06"
       },
       "parent_id": "Q1243"
     },
@@ -59410,7 +59410,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 07"
+        "lang:it": "Veneto 1 - 07"
       },
       "parent_id": "Q1243"
     },
@@ -59434,7 +59434,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 1 - 08"
+        "lang:it": "Veneto 1 - 08"
       },
       "parent_id": "Q1243"
     },
@@ -59458,7 +59458,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 01"
+        "lang:it": "Veneto 2 - 01"
       },
       "parent_id": "Q1243"
     },
@@ -59482,7 +59482,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 02"
+        "lang:it": "Veneto 2 - 02"
       },
       "parent_id": "Q1243"
     },
@@ -59506,7 +59506,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 03"
+        "lang:it": "Veneto 2 - 03"
       },
       "parent_id": "Q1243"
     },
@@ -59530,7 +59530,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 04"
+        "lang:it": "Veneto 2 - 04"
       },
       "parent_id": "Q1243"
     },
@@ -59554,7 +59554,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 05"
+        "lang:it": "Veneto 2 - 05"
       },
       "parent_id": "Q1243"
     },
@@ -59578,7 +59578,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 06"
+        "lang:it": "Veneto 2 - 06"
       },
       "parent_id": "Q1243"
     },
@@ -59602,7 +59602,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 07"
+        "lang:it": "Veneto 2 - 07"
       },
       "parent_id": "Q1243"
     },
@@ -59626,7 +59626,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 08"
+        "lang:it": "Veneto 2 - 08"
       },
       "parent_id": "Q1243"
     },
@@ -59650,7 +59650,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 09"
+        "lang:it": "Veneto 2 - 09"
       },
       "parent_id": "Q1243"
     },
@@ -59674,7 +59674,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 10"
+        "lang:it": "Veneto 2 - 10"
       },
       "parent_id": "Q1243"
     },
@@ -59698,7 +59698,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Veneto 2 - 11"
+        "lang:it": "Veneto 2 - 11"
       },
       "parent_id": "Q1243"
     },
@@ -59722,7 +59722,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 01"
+        "lang:it": "Friuli-Venezia Giulia - 01"
       },
       "parent_id": "Q1250"
     },
@@ -59746,7 +59746,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 02"
+        "lang:it": "Friuli-Venezia Giulia - 02"
       },
       "parent_id": "Q1250"
     },
@@ -59770,7 +59770,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 03"
+        "lang:it": "Friuli-Venezia Giulia - 03"
       },
       "parent_id": "Q1250"
     },
@@ -59794,7 +59794,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 04"
+        "lang:it": "Friuli-Venezia Giulia - 04"
       },
       "parent_id": "Q1250"
     },
@@ -59818,7 +59818,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Friuli-Venezia Giulia - 05"
+        "lang:it": "Friuli-Venezia Giulia - 05"
       },
       "parent_id": "Q1250"
     },
@@ -59842,7 +59842,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Liguria - 01"
+        "lang:it": "Liguria - 01"
       },
       "parent_id": "Q1256"
     },
@@ -59866,7 +59866,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Liguria - 02"
+        "lang:it": "Liguria - 02"
       },
       "parent_id": "Q1256"
     },
@@ -59890,7 +59890,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Liguria - 03"
+        "lang:it": "Liguria - 03"
       },
       "parent_id": "Q1256"
     },
@@ -59914,7 +59914,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Liguria - 04"
+        "lang:it": "Liguria - 04"
       },
       "parent_id": "Q1256"
     },
@@ -59938,7 +59938,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Liguria - 05"
+        "lang:it": "Liguria - 05"
       },
       "parent_id": "Q1256"
     },
@@ -59962,7 +59962,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Liguria - 06"
+        "lang:it": "Liguria - 06"
       },
       "parent_id": "Q1256"
     },
@@ -59986,7 +59986,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 01"
+        "lang:it": "Emilia-Romagna - 01"
       },
       "parent_id": "Q1263"
     },
@@ -60010,7 +60010,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 02"
+        "lang:it": "Emilia-Romagna - 02"
       },
       "parent_id": "Q1263"
     },
@@ -60034,7 +60034,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 03"
+        "lang:it": "Emilia-Romagna - 03"
       },
       "parent_id": "Q1263"
     },
@@ -60058,7 +60058,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 04"
+        "lang:it": "Emilia-Romagna - 04"
       },
       "parent_id": "Q1263"
     },
@@ -60082,7 +60082,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 05"
+        "lang:it": "Emilia-Romagna - 05"
       },
       "parent_id": "Q1263"
     },
@@ -60106,7 +60106,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 06"
+        "lang:it": "Emilia-Romagna - 06"
       },
       "parent_id": "Q1263"
     },
@@ -60130,7 +60130,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 07"
+        "lang:it": "Emilia-Romagna - 07"
       },
       "parent_id": "Q1263"
     },
@@ -60154,7 +60154,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 08"
+        "lang:it": "Emilia-Romagna - 08"
       },
       "parent_id": "Q1263"
     },
@@ -60178,7 +60178,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 09"
+        "lang:it": "Emilia-Romagna - 09"
       },
       "parent_id": "Q1263"
     },
@@ -60202,7 +60202,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 10"
+        "lang:it": "Emilia-Romagna - 10"
       },
       "parent_id": "Q1263"
     },
@@ -60226,7 +60226,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 11"
+        "lang:it": "Emilia-Romagna - 11"
       },
       "parent_id": "Q1263"
     },
@@ -60250,7 +60250,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 12"
+        "lang:it": "Emilia-Romagna - 12"
       },
       "parent_id": "Q1263"
     },
@@ -60274,7 +60274,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 13"
+        "lang:it": "Emilia-Romagna - 13"
       },
       "parent_id": "Q1263"
     },
@@ -60298,7 +60298,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 14"
+        "lang:it": "Emilia-Romagna - 14"
       },
       "parent_id": "Q1263"
     },
@@ -60322,7 +60322,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 15"
+        "lang:it": "Emilia-Romagna - 15"
       },
       "parent_id": "Q1263"
     },
@@ -60346,7 +60346,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 16"
+        "lang:it": "Emilia-Romagna - 16"
       },
       "parent_id": "Q1263"
     },
@@ -60370,7 +60370,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Emilia-Romagna - 17"
+        "lang:it": "Emilia-Romagna - 17"
       },
       "parent_id": "Q1263"
     },
@@ -60394,7 +60394,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 01"
+        "lang:it": "Toscana - 01"
       },
       "parent_id": "Q1273"
     },
@@ -60418,7 +60418,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 02"
+        "lang:it": "Toscana - 02"
       },
       "parent_id": "Q1273"
     },
@@ -60442,7 +60442,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 03"
+        "lang:it": "Toscana - 03"
       },
       "parent_id": "Q1273"
     },
@@ -60466,7 +60466,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 04"
+        "lang:it": "Toscana - 04"
       },
       "parent_id": "Q1273"
     },
@@ -60490,7 +60490,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 05"
+        "lang:it": "Toscana - 05"
       },
       "parent_id": "Q1273"
     },
@@ -60514,7 +60514,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 06"
+        "lang:it": "Toscana - 06"
       },
       "parent_id": "Q1273"
     },
@@ -60538,7 +60538,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 07"
+        "lang:it": "Toscana - 07"
       },
       "parent_id": "Q1273"
     },
@@ -60562,7 +60562,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 08"
+        "lang:it": "Toscana - 08"
       },
       "parent_id": "Q1273"
     },
@@ -60586,7 +60586,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 09"
+        "lang:it": "Toscana - 09"
       },
       "parent_id": "Q1273"
     },
@@ -60610,7 +60610,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 10"
+        "lang:it": "Toscana - 10"
       },
       "parent_id": "Q1273"
     },
@@ -60634,7 +60634,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 11"
+        "lang:it": "Toscana - 11"
       },
       "parent_id": "Q1273"
     },
@@ -60658,7 +60658,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 12"
+        "lang:it": "Toscana - 12"
       },
       "parent_id": "Q1273"
     },
@@ -60682,7 +60682,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 13"
+        "lang:it": "Toscana - 13"
       },
       "parent_id": "Q1273"
     },
@@ -60706,7 +60706,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Toscana - 14"
+        "lang:it": "Toscana - 14"
       },
       "parent_id": "Q1273"
     },
@@ -60730,7 +60730,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Umbria - 01"
+        "lang:it": "Umbria - 01"
       },
       "parent_id": "Q1280"
     },
@@ -60754,7 +60754,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Umbria - 02"
+        "lang:it": "Umbria - 02"
       },
       "parent_id": "Q1280"
     },
@@ -60778,7 +60778,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Umbria - 03"
+        "lang:it": "Umbria - 03"
       },
       "parent_id": "Q1280"
     },
@@ -60802,7 +60802,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Marche - 01"
+        "lang:it": "Marche - 01"
       },
       "parent_id": "Q1279"
     },
@@ -60826,7 +60826,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Marche - 02"
+        "lang:it": "Marche - 02"
       },
       "parent_id": "Q1279"
     },
@@ -60850,7 +60850,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Marche - 03"
+        "lang:it": "Marche - 03"
       },
       "parent_id": "Q1279"
     },
@@ -60874,7 +60874,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Marche - 04"
+        "lang:it": "Marche - 04"
       },
       "parent_id": "Q1279"
     },
@@ -60898,7 +60898,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Marche - 05"
+        "lang:it": "Marche - 05"
       },
       "parent_id": "Q1279"
     },
@@ -60922,7 +60922,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Marche - 06"
+        "lang:it": "Marche - 06"
       },
       "parent_id": "Q1279"
     },
@@ -60946,7 +60946,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 01"
+        "lang:it": "Lazio 1 - 01"
       },
       "parent_id": "Q1282"
     },
@@ -60970,7 +60970,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 02"
+        "lang:it": "Lazio 1 - 02"
       },
       "parent_id": "Q1282"
     },
@@ -60994,7 +60994,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 03"
+        "lang:it": "Lazio 1 - 03"
       },
       "parent_id": "Q1282"
     },
@@ -61018,7 +61018,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 04"
+        "lang:it": "Lazio 1 - 04"
       },
       "parent_id": "Q1282"
     },
@@ -61042,7 +61042,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 05"
+        "lang:it": "Lazio 1 - 05"
       },
       "parent_id": "Q1282"
     },
@@ -61066,7 +61066,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 06"
+        "lang:it": "Lazio 1 - 06"
       },
       "parent_id": "Q1282"
     },
@@ -61090,7 +61090,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 07"
+        "lang:it": "Lazio 1 - 07"
       },
       "parent_id": "Q1282"
     },
@@ -61114,7 +61114,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 08"
+        "lang:it": "Lazio 1 - 08"
       },
       "parent_id": "Q1282"
     },
@@ -61138,7 +61138,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 09"
+        "lang:it": "Lazio 1 - 09"
       },
       "parent_id": "Q1282"
     },
@@ -61162,7 +61162,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 10"
+        "lang:it": "Lazio 1 - 10"
       },
       "parent_id": "Q1282"
     },
@@ -61186,7 +61186,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 11"
+        "lang:it": "Lazio 1 - 11"
       },
       "parent_id": "Q1282"
     },
@@ -61210,7 +61210,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 12"
+        "lang:it": "Lazio 1 - 12"
       },
       "parent_id": "Q1282"
     },
@@ -61234,7 +61234,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 13"
+        "lang:it": "Lazio 1 - 13"
       },
       "parent_id": "Q1282"
     },
@@ -61258,7 +61258,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 1 - 14"
+        "lang:it": "Lazio 1 - 14"
       },
       "parent_id": "Q1282"
     },
@@ -61282,7 +61282,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 01"
+        "lang:it": "Lazio 2 - 01"
       },
       "parent_id": "Q1282"
     },
@@ -61306,7 +61306,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 02"
+        "lang:it": "Lazio 2 - 02"
       },
       "parent_id": "Q1282"
     },
@@ -61330,7 +61330,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 03"
+        "lang:it": "Lazio 2 - 03"
       },
       "parent_id": "Q1282"
     },
@@ -61354,7 +61354,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 04"
+        "lang:it": "Lazio 2 - 04"
       },
       "parent_id": "Q1282"
     },
@@ -61378,7 +61378,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 05"
+        "lang:it": "Lazio 2 - 05"
       },
       "parent_id": "Q1282"
     },
@@ -61402,7 +61402,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 06"
+        "lang:it": "Lazio 2 - 06"
       },
       "parent_id": "Q1282"
     },
@@ -61426,7 +61426,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Lazio 2 - 07"
+        "lang:it": "Lazio 2 - 07"
       },
       "parent_id": "Q1282"
     },
@@ -61450,7 +61450,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 04"
+        "lang:it": "Abruzzo - 04"
       },
       "parent_id": "Q1284"
     },
@@ -61474,7 +61474,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Abruzzo - 05"
+        "lang:it": "Abruzzo - 05"
       },
       "parent_id": "Q1284"
     },
@@ -61498,7 +61498,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Molise - 01"
+        "lang:it": "Molise - 01"
       },
       "parent_id": "Q1443"
     },
@@ -61522,7 +61522,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Molise - 02"
+        "lang:it": "Molise - 02"
       },
       "parent_id": "Q1443"
     },
@@ -61546,7 +61546,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 01"
+        "lang:it": "Campania 1 - 01"
       },
       "parent_id": "Q1438"
     },
@@ -61570,7 +61570,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 02"
+        "lang:it": "Campania 1 - 02"
       },
       "parent_id": "Q1438"
     },
@@ -61594,7 +61594,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 03"
+        "lang:it": "Campania 1 - 03"
       },
       "parent_id": "Q1438"
     },
@@ -61618,7 +61618,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 04"
+        "lang:it": "Campania 1 - 04"
       },
       "parent_id": "Q1438"
     },
@@ -61642,7 +61642,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 05"
+        "lang:it": "Campania 1 - 05"
       },
       "parent_id": "Q1438"
     },
@@ -61666,7 +61666,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 06"
+        "lang:it": "Campania 1 - 06"
       },
       "parent_id": "Q1438"
     },
@@ -61690,7 +61690,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 07"
+        "lang:it": "Campania 1 - 07"
       },
       "parent_id": "Q1438"
     },
@@ -61714,7 +61714,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 08"
+        "lang:it": "Campania 1 - 08"
       },
       "parent_id": "Q1438"
     },
@@ -61738,7 +61738,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 09"
+        "lang:it": "Campania 1 - 09"
       },
       "parent_id": "Q1438"
     },
@@ -61762,7 +61762,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 10"
+        "lang:it": "Campania 1 - 10"
       },
       "parent_id": "Q1438"
     },
@@ -61786,7 +61786,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 11"
+        "lang:it": "Campania 1 - 11"
       },
       "parent_id": "Q1438"
     },
@@ -61810,7 +61810,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 1 - 12"
+        "lang:it": "Campania 1 - 12"
       },
       "parent_id": "Q1438"
     },
@@ -61834,7 +61834,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 01"
+        "lang:it": "Campania 2 - 01"
       },
       "parent_id": "Q1438"
     },
@@ -61858,7 +61858,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 02"
+        "lang:it": "Campania 2 - 02"
       },
       "parent_id": "Q1438"
     },
@@ -61882,7 +61882,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 03"
+        "lang:it": "Campania 2 - 03"
       },
       "parent_id": "Q1438"
     },
@@ -61906,7 +61906,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 04"
+        "lang:it": "Campania 2 - 04"
       },
       "parent_id": "Q1438"
     },
@@ -61930,7 +61930,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 05"
+        "lang:it": "Campania 2 - 05"
       },
       "parent_id": "Q1438"
     },
@@ -61954,7 +61954,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 06"
+        "lang:it": "Campania 2 - 06"
       },
       "parent_id": "Q1438"
     },
@@ -61978,7 +61978,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 07"
+        "lang:it": "Campania 2 - 07"
       },
       "parent_id": "Q1438"
     },
@@ -62002,7 +62002,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 08"
+        "lang:it": "Campania 2 - 08"
       },
       "parent_id": "Q1438"
     },
@@ -62026,7 +62026,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 09"
+        "lang:it": "Campania 2 - 09"
       },
       "parent_id": "Q1438"
     },
@@ -62050,7 +62050,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Campania 2 - 10"
+        "lang:it": "Campania 2 - 10"
       },
       "parent_id": "Q1438"
     },
@@ -62074,7 +62074,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 01"
+        "lang:it": "Puglia - 01"
       },
       "parent_id": "Q1447"
     },
@@ -62098,7 +62098,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 02"
+        "lang:it": "Puglia - 02"
       },
       "parent_id": "Q1447"
     },
@@ -62122,7 +62122,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 03"
+        "lang:it": "Puglia - 03"
       },
       "parent_id": "Q1447"
     },
@@ -62146,7 +62146,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 04"
+        "lang:it": "Puglia - 04"
       },
       "parent_id": "Q1447"
     },
@@ -62170,7 +62170,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 05"
+        "lang:it": "Puglia - 05"
       },
       "parent_id": "Q1447"
     },
@@ -62194,7 +62194,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 06"
+        "lang:it": "Puglia - 06"
       },
       "parent_id": "Q1447"
     },
@@ -62218,7 +62218,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 07"
+        "lang:it": "Puglia - 07"
       },
       "parent_id": "Q1447"
     },
@@ -62242,7 +62242,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 08"
+        "lang:it": "Puglia - 08"
       },
       "parent_id": "Q1447"
     },
@@ -62266,7 +62266,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 09"
+        "lang:it": "Puglia - 09"
       },
       "parent_id": "Q1447"
     },
@@ -62290,7 +62290,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 10"
+        "lang:it": "Puglia - 10"
       },
       "parent_id": "Q1447"
     },
@@ -62314,7 +62314,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 11"
+        "lang:it": "Puglia - 11"
       },
       "parent_id": "Q1447"
     },
@@ -62338,7 +62338,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 12"
+        "lang:it": "Puglia - 12"
       },
       "parent_id": "Q1447"
     },
@@ -62362,7 +62362,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 13"
+        "lang:it": "Puglia - 13"
       },
       "parent_id": "Q1447"
     },
@@ -62386,7 +62386,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 14"
+        "lang:it": "Puglia - 14"
       },
       "parent_id": "Q1447"
     },
@@ -62410,7 +62410,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 15"
+        "lang:it": "Puglia - 15"
       },
       "parent_id": "Q1447"
     },
@@ -62434,7 +62434,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Puglia - 16"
+        "lang:it": "Puglia - 16"
       },
       "parent_id": "Q1447"
     },
@@ -62458,7 +62458,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Basilicata - 01"
+        "lang:it": "Basilicata - 01"
       },
       "parent_id": "Q1452"
     },
@@ -62482,7 +62482,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Basilicata - 02"
+        "lang:it": "Basilicata - 02"
       },
       "parent_id": "Q1452"
     },
@@ -62506,7 +62506,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 01"
+        "lang:it": "Calabria - 01"
       },
       "parent_id": "Q1458"
     },
@@ -62530,7 +62530,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 02"
+        "lang:it": "Calabria - 02"
       },
       "parent_id": "Q1458"
     },
@@ -62554,7 +62554,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 03"
+        "lang:it": "Calabria - 03"
       },
       "parent_id": "Q1458"
     },
@@ -62578,7 +62578,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 04"
+        "lang:it": "Calabria - 04"
       },
       "parent_id": "Q1458"
     },
@@ -62602,7 +62602,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 05"
+        "lang:it": "Calabria - 05"
       },
       "parent_id": "Q1458"
     },
@@ -62626,7 +62626,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 06"
+        "lang:it": "Calabria - 06"
       },
       "parent_id": "Q1458"
     },
@@ -62650,7 +62650,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 07"
+        "lang:it": "Calabria - 07"
       },
       "parent_id": "Q1458"
     },
@@ -62674,7 +62674,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Calabria - 08"
+        "lang:it": "Calabria - 08"
       },
       "parent_id": "Q1458"
     },
@@ -62698,7 +62698,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 01"
+        "lang:it": "Sicilia 1 - 01"
       },
       "parent_id": "Q1460"
     },
@@ -62722,7 +62722,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 02"
+        "lang:it": "Sicilia 1 - 02"
       },
       "parent_id": "Q1460"
     },
@@ -62746,7 +62746,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 03"
+        "lang:it": "Sicilia 1 - 03"
       },
       "parent_id": "Q1460"
     },
@@ -62770,7 +62770,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 04"
+        "lang:it": "Sicilia 1 - 04"
       },
       "parent_id": "Q1460"
     },
@@ -62794,7 +62794,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 05"
+        "lang:it": "Sicilia 1 - 05"
       },
       "parent_id": "Q1460"
     },
@@ -62818,7 +62818,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 06"
+        "lang:it": "Sicilia 1 - 06"
       },
       "parent_id": "Q1460"
     },
@@ -62842,7 +62842,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 07"
+        "lang:it": "Sicilia 1 - 07"
       },
       "parent_id": "Q1460"
     },
@@ -62866,7 +62866,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 08"
+        "lang:it": "Sicilia 1 - 08"
       },
       "parent_id": "Q1460"
     },
@@ -62890,7 +62890,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 1 - 09"
+        "lang:it": "Sicilia 1 - 09"
       },
       "parent_id": "Q1460"
     },
@@ -62914,7 +62914,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 01"
+        "lang:it": "Sicilia 2 - 01"
       },
       "parent_id": "Q1460"
     },
@@ -62938,7 +62938,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 02"
+        "lang:it": "Sicilia 2 - 02"
       },
       "parent_id": "Q1460"
     },
@@ -62962,7 +62962,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 03"
+        "lang:it": "Sicilia 2 - 03"
       },
       "parent_id": "Q1460"
     },
@@ -62986,7 +62986,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 04"
+        "lang:it": "Sicilia 2 - 04"
       },
       "parent_id": "Q1460"
     },
@@ -63010,7 +63010,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 05"
+        "lang:it": "Sicilia 2 - 05"
       },
       "parent_id": "Q1460"
     },
@@ -63034,7 +63034,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 06"
+        "lang:it": "Sicilia 2 - 06"
       },
       "parent_id": "Q1460"
     },
@@ -63058,7 +63058,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 07"
+        "lang:it": "Sicilia 2 - 07"
       },
       "parent_id": "Q1460"
     },
@@ -63082,7 +63082,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 08"
+        "lang:it": "Sicilia 2 - 08"
       },
       "parent_id": "Q1460"
     },
@@ -63106,7 +63106,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 09"
+        "lang:it": "Sicilia 2 - 09"
       },
       "parent_id": "Q1460"
     },
@@ -63130,7 +63130,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sicilia 2 - 10"
+        "lang:it": "Sicilia 2 - 10"
       },
       "parent_id": "Q1460"
     },
@@ -63154,7 +63154,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 01"
+        "lang:it": "Sardegna - 01"
       },
       "parent_id": "Q1462"
     },
@@ -63178,7 +63178,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 02"
+        "lang:it": "Sardegna - 02"
       },
       "parent_id": "Q1462"
     },
@@ -63202,7 +63202,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 03"
+        "lang:it": "Sardegna - 03"
       },
       "parent_id": "Q1462"
     },
@@ -63226,7 +63226,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 04"
+        "lang:it": "Sardegna - 04"
       },
       "parent_id": "Q1462"
     },
@@ -63250,7 +63250,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 05"
+        "lang:it": "Sardegna - 05"
       },
       "parent_id": "Q1462"
     },
@@ -63274,7 +63274,7 @@
         "lang:en": "uninominal constituency of the Italian Chamber of Deputies"
       },
       "name": {
-        "lang:it_IT": "Sardegna - 06"
+        "lang:it": "Sardegna - 06"
       },
       "parent_id": "Q1462"
     }


### PR DESCRIPTION
I forgot to update boundaries/index.json with the new language codes when moving to Wikidata codes in aebb2d7, so this fixes that. Confirmed that none of the old codes are now present in the repo.